### PR TITLE
Open map chunk when factory is built

### DIFF
--- a/src/buildings/factory.js
+++ b/src/buildings/factory.js
@@ -175,6 +175,9 @@ export class Factory {
         this.isUnderConstruction = false;
         this.currentHealth = this.maxHealth;
         gameState.factoryBuilt = true;
+        if (typeof gameState.onFactoryBuilt === 'function') {
+            gameState.onFactoryBuilt();
+        }
 
         this.mesh.scale.y = 1.0;
         this.mesh.traverse(child => {

--- a/src/game/gameState.js
+++ b/src/game/gameState.js
@@ -28,4 +28,6 @@ export const gameState = {
     covertOpsBuilt: false,
     comsatStationBuilt: false,
     nuclearSiloBuilt: false,
+    onFactoryBuilt: null,
+    mapChunksUnlocked: 1,
 };

--- a/src/game/index.js
+++ b/src/game/index.js
@@ -17,7 +17,7 @@ import { initMobileControls } from './mobileControls.js';
 import { devLogger } from '../utils/dev-logger.js';
 import { setupInitialState } from './initial-state.js';
 
-let scene, camera, renderer, controls, pathfinder, terrainObstacles, gridHelper;
+let scene, camera, renderer, controls, pathfinder, terrainObstacles, gridHelper, expansionBarrier;
 let units = [];
 let buildings = [];
 let mineralFields = [];
@@ -28,6 +28,18 @@ const audioManager = new AudioManager();
 const keyState = {};
 let gameContainer;
 let devModeActive = false;
+
+function openMapChunk() {
+    if (!expansionBarrier) return;
+    scene.remove(expansionBarrier.mesh);
+    const idx = collidableObjects.indexOf(expansionBarrier);
+    if (idx !== -1) collidableObjects.splice(idx, 1);
+    const obsIdx = terrainObstacles.indexOf(expansionBarrier);
+    if (obsIdx !== -1) terrainObstacles.splice(obsIdx, 1);
+    pathfinder.updateObstacles(collidableObjects);
+    gameState.mapChunksUnlocked += 1;
+    expansionBarrier = null;
+}
 
 function init() {
     gameContainer = document.getElementById('game-container');
@@ -74,7 +86,9 @@ async function startGame() {
     controls = sceneData.controls;
     pathfinder = sceneData.pathfinder;
     terrainObstacles = sceneData.terrainObstacles;
+    expansionBarrier = sceneData.chunkBarrier;
     gridHelper = sceneData.gridHelper;
+    gameState.onFactoryBuilt = openMapChunk;
 
     initSpawner({ scene, units, buildings, selectables, collidableObjects, pathfinder, gameState, audioManager });
     initEffects(scene);

--- a/src/game/map.js
+++ b/src/game/map.js
@@ -100,5 +100,26 @@ export function createMap(width, height) {
     addBorderPlateau(westX, 0, borderSize, height - 2 * borderSize);
     addBorderPlateau(eastX, 0, borderSize, height - 2 * borderSize);
 
-    return { mesh: group, obstacles };
+    // Barrier blocking the eastern chunk until unlocked
+    const barrierWidth = 2;
+    const barrierHeight = 4;
+    const barrierDepth = height - 2 * borderSize;
+    const barrierX = width / 4;
+    const barrierGeom = new THREE.BoxGeometry(barrierWidth, barrierHeight, barrierDepth);
+    const barrierMesh = new THREE.Mesh(barrierGeom, material);
+    barrierMesh.position.set(barrierX, barrierHeight / 2, 0);
+    group.add(barrierMesh);
+
+    const barrierCollider = new THREE.Box3(
+        new THREE.Vector3(barrierX - barrierWidth / 2, 0, -barrierDepth / 2),
+        new THREE.Vector3(barrierX + barrierWidth / 2, barrierHeight, barrierDepth / 2)
+    );
+    const chunkBarrier = {
+        mesh: barrierMesh,
+        collider: barrierCollider,
+        getCollider() { return this.collider; }
+    };
+    obstacles.push(chunkBarrier);
+
+    return { mesh: group, obstacles, chunkBarrier };
 }

--- a/src/game/setupScene.js
+++ b/src/game/setupScene.js
@@ -28,7 +28,7 @@ export function setupScene(container) {
 
     const mapWidth = 128;
     const mapHeight = 128;
-    const { mesh: mapMesh, obstacles: terrainObstacles } = createMap(mapWidth, mapHeight);
+    const { mesh: mapMesh, obstacles: terrainObstacles, chunkBarrier } = createMap(mapWidth, mapHeight);
     scene.add(mapMesh);
 
     const gridHelper = new THREE.GridHelper(mapWidth, mapWidth, 0xaaaaaa, 0x666666);
@@ -51,5 +51,5 @@ export function setupScene(container) {
     directionalLight.shadow.mapSize.height = 2048;
     scene.add(directionalLight);
 
-    return { scene, camera, renderer, controls, pathfinder, terrainObstacles, mapWidth, mapHeight, gridHelper };
+    return { scene, camera, renderer, controls, pathfinder, terrainObstacles, mapWidth, mapHeight, gridHelper, chunkBarrier };
 }


### PR DESCRIPTION
## Summary
- add map unlocking hook in game state
- create barrier to an additional map chunk
- expose barrier in scene setup and remove it once a Factory completes
- trigger chunk opening in Factory.onConstructionComplete

## Testing
- `python3 -m http.server 8000` *(fails: no output due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_6856f5b80c20833288233c9cd162e1a1