### PR TITLE
Map expands after first factory

### DIFF
--- a/src/game/minimap.js
+++ b/src/game/minimap.js
@@ -17,6 +17,18 @@ let frustumLine;
 const spritePool = [];
 let activeSprites = [];
 
+export function setMapSize(newWidth, newHeight) {
+    mapWidth = newWidth;
+    mapHeight = newHeight;
+    if (minimapCamera) {
+        minimapCamera.left = -mapWidth / 2;
+        minimapCamera.right = mapWidth / 2;
+        minimapCamera.top = mapHeight / 2;
+        minimapCamera.bottom = -mapHeight / 2;
+        minimapCamera.updateProjectionMatrix();
+    }
+}
+
 export function init(deps) {
     mainCamera = deps.camera;
     mainControls = deps.controls;

--- a/src/game/placement.js
+++ b/src/game/placement.js
@@ -2,8 +2,13 @@ import * as THREE from 'three';
 import { updateStatusText, updatePlacementText } from './ui.js';
 import { spawnBuilding } from './spawn.js';
 import { gameState } from './gameState.js';
+import { getGroundMeshes } from '../utils/terrain.js';
 
 let scene, camera, renderer, vespeneGeysers, collidableObjects, pathfinder;
+
+export function setPathfinder(newPathfinder) {
+    pathfinder = newPathfinder;
+}
 
 export let placementMode = null;
 let ghostBuilding = null;
@@ -100,9 +105,8 @@ export function updateGhostBuilding(event) {
 
     raycaster.setFromCamera(mouse, camera);
 
-    const groundGroup = scene.getObjectByName('ground');
-    if (groundGroup) {
-        const groundMeshes = groundGroup.children.length > 0 ? groundGroup.children : [groundGroup];
+    const groundMeshes = getGroundMeshes(scene);
+    if (groundMeshes.length > 0) {
         const intersects = raycaster.intersectObjects(groundMeshes, true);
         if (intersects.length > 0) {
             const hit = intersects[0];
@@ -131,10 +135,9 @@ export function attemptPlacement(event) {
 
     const raycaster = new THREE.Raycaster();
     raycaster.setFromCamera(mouse, camera);
-    const groundGroup = scene.getObjectByName('ground');
-    if (!groundGroup) return;
+    const groundMeshes = getGroundMeshes(scene);
+    if (groundMeshes.length === 0) return;
 
-    const groundMeshes = groundGroup.children.length > 0 ? groundGroup.children : [groundGroup];
     const intersects = raycaster.intersectObjects(groundMeshes, true);
     if (intersects.length > 0) {
         const hit = intersects[0];

--- a/src/game/rightClickHandler.js
+++ b/src/game/rightClickHandler.js
@@ -7,11 +7,16 @@ import { SCVMark2 } from '../units/scv-mark-2.js';
 import { Bunker } from '../buildings/bunker.js';
 import { Dropship } from '../units/dropship.js';
 import { devLogger } from '../utils/dev-logger.js';
+import { getGroundMeshes } from '../utils/terrain.js';
 
 const raycaster = new THREE.Raycaster();
 const mouse = new THREE.Vector2();
 
 let camera, scene, allSelectables, onMoveSound, createMoveIndicator, pathfinder, updateStatusText;
+
+export function setPathfinder(newPathfinder) {
+    pathfinder = newPathfinder;
+}
 let allBuildings = [];
 let allMineralFields = [];
 let getSelectedObjects;
@@ -218,10 +223,9 @@ export function handleRightClick(event) {
         }
     }
     
-    const groundGroup = scene.getObjectByName('ground');
-    if (!groundGroup) return;
+    const groundMeshes = getGroundMeshes(scene);
+    if (groundMeshes.length === 0) return;
 
-    const groundMeshes = groundGroup.children.length > 0 ? groundGroup.children : [groundGroup];
     const groundIntersects = raycaster.intersectObjects(groundMeshes, true);
 
     if (groundIntersects.length > 0) {

--- a/src/game/spawn.js
+++ b/src/game/spawn.js
@@ -33,6 +33,12 @@ import { PhysicsLab } from '../buildings/physics-lab.js';
 
 let deps;
 
+export function setPathfinder(newPathfinder) {
+    if (deps) {
+        deps.pathfinder = newPathfinder;
+    }
+}
+
 export function initSpawner(_deps) {
     deps = _deps;
 }

--- a/src/utils/terrain.js
+++ b/src/utils/terrain.js
@@ -1,8 +1,16 @@
 import * as THREE from 'three';
 
+export function getGroundMeshes(scene) {
+    const grounds = [];
+    scene.traverse(obj => {
+        if (obj.name === 'ground') grounds.push(obj);
+    });
+    return grounds;
+}
+
 export function sampleTerrain(scene, x, z) {
-    const ground = scene.getObjectByName('ground');
-    if (!ground) {
+    const grounds = getGroundMeshes(scene);
+    if (grounds.length === 0) {
         return { height: 0, normal: new THREE.Vector3(0, 1, 0) };
     }
 
@@ -10,10 +18,10 @@ export function sampleTerrain(scene, x, z) {
         new THREE.Vector3(x, 1000, z),
         new THREE.Vector3(0, -1, 0)
     );
-    const intersects = raycaster.intersectObject(ground, false);
+    const intersects = raycaster.intersectObjects(grounds, true);
     if (intersects.length > 0) {
         const hit = intersects[0];
-        const normalMatrix = new THREE.Matrix3().getNormalMatrix(ground.matrixWorld);
+        const normalMatrix = new THREE.Matrix3().getNormalMatrix(hit.object.matrixWorld);
         const normal = hit.face.normal.clone().applyMatrix3(normalMatrix).normalize();
         return { height: hit.point.y, normal };
     }


### PR DESCRIPTION
## Summary
- support multiple ground meshes
- allow updating the pathfinder in spawn, placement and right‑click handler modules
- add map size updating logic for the minimap
- expand map and pathfinder when the first factory finishes

## Testing
- `python3 -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_6856fa40233883329dca7a10b8936a89