### PR TITLE
Remove central barrier and ring expansion area

### DIFF
--- a/src/game/index.js
+++ b/src/game/index.js
@@ -19,7 +19,7 @@ import { setupInitialState } from './initial-state.js';
 import { setPathfinder as setRCHPathfinder } from './rightClickHandler.js';
 import { Pathfinder } from '../utils/pathfinding.js';
 
-let scene, camera, renderer, controls, pathfinder, terrainObstacles, gridHelper, expansionBarrier;
+let scene, camera, renderer, controls, pathfinder, terrainObstacles, gridHelper;
 let mapWidth, mapHeight;
 let loopDeps;
 let units = [];
@@ -34,13 +34,6 @@ let gameContainer;
 let devModeActive = false;
 
 function openMapChunk() {
-    if (!expansionBarrier) return;
-    scene.remove(expansionBarrier.mesh);
-    const idx = collidableObjects.indexOf(expansionBarrier);
-    if (idx !== -1) collidableObjects.splice(idx, 1);
-    const obsIdx = terrainObstacles.indexOf(expansionBarrier);
-    if (obsIdx !== -1) terrainObstacles.splice(obsIdx, 1);
-    expansionBarrier = null;
 
     const groundTexture = assetManager.get('ground');
     groundTexture.wrapS = groundTexture.wrapT = THREE.RepeatWrapping;
@@ -57,6 +50,40 @@ function openMapChunk() {
     newGround.name = 'ground';
     newGround.position.set(mapWidth, 0, 0);
     scene.add(newGround);
+
+    const borderSize = 10;
+    const plateauHeight = 2;
+    function addBorderPlateau(x, z, sizeX, sizeZ) {
+        const plateauGeom = new THREE.BoxGeometry(sizeX, plateauHeight, sizeZ);
+        const plateau = new THREE.Mesh(plateauGeom, material);
+        plateau.position.set(x, plateauHeight / 2, z);
+        plateau.castShadow = true;
+        plateau.receiveShadow = true;
+        scene.add(plateau);
+
+        const minX = x - sizeX / 2;
+        const maxX = x + sizeX / 2;
+        const minZ = z - sizeZ / 2;
+        const maxZ = z + sizeZ / 2;
+        const obstacle = {
+            collider: new THREE.Box3(
+                new THREE.Vector3(minX, 0, minZ),
+                new THREE.Vector3(maxX, plateauHeight, maxZ)
+            ),
+            getCollider() { return this.collider; }
+        };
+        terrainObstacles.push(obstacle);
+        collidableObjects.push(obstacle);
+    }
+
+    const baseX = mapWidth;
+    const northZ = mapHeight / 2 - borderSize / 2;
+    const southZ = -mapHeight / 2 + borderSize / 2;
+    const eastX = baseX + mapWidth / 2 - borderSize / 2;
+
+    addBorderPlateau(baseX, northZ, mapWidth, borderSize);
+    addBorderPlateau(baseX, southZ, mapWidth, borderSize);
+    addBorderPlateau(eastX, 0, borderSize, mapHeight - 2 * borderSize);
 
     gameState.mapChunksUnlocked += 1;
 
@@ -117,7 +144,6 @@ async function startGame() {
     pathfinder = sceneData.pathfinder;
     window.pathfinder = pathfinder;
     terrainObstacles = sceneData.terrainObstacles;
-    expansionBarrier = sceneData.chunkBarrier;
     gridHelper = sceneData.gridHelper;
     mapWidth = sceneData.mapWidth;
     mapHeight = sceneData.mapHeight;

--- a/src/game/map.js
+++ b/src/game/map.js
@@ -98,28 +98,7 @@ export function createMap(width, height) {
     addBorderPlateau(0, northZ, width, borderSize);
     addBorderPlateau(0, southZ, width, borderSize);
     addBorderPlateau(westX, 0, borderSize, height - 2 * borderSize);
-    addBorderPlateau(eastX, 0, borderSize, height - 2 * borderSize);
+    // The eastern edge will be left open for future expansion
 
-    // Barrier blocking the eastern chunk until unlocked
-    const barrierWidth = 2;
-    const barrierHeight = 4;
-    const barrierDepth = height - 2 * borderSize;
-    const barrierX = width / 4;
-    const barrierGeom = new THREE.BoxGeometry(barrierWidth, barrierHeight, barrierDepth);
-    const barrierMesh = new THREE.Mesh(barrierGeom, material);
-    barrierMesh.position.set(barrierX, barrierHeight / 2, 0);
-    group.add(barrierMesh);
-
-    const barrierCollider = new THREE.Box3(
-        new THREE.Vector3(barrierX - barrierWidth / 2, 0, -barrierDepth / 2),
-        new THREE.Vector3(barrierX + barrierWidth / 2, barrierHeight, barrierDepth / 2)
-    );
-    const chunkBarrier = {
-        mesh: barrierMesh,
-        collider: barrierCollider,
-        getCollider() { return this.collider; }
-    };
-    obstacles.push(chunkBarrier);
-
-    return { mesh: group, obstacles, chunkBarrier };
+    return { mesh: group, obstacles };
 }

--- a/src/game/setupScene.js
+++ b/src/game/setupScene.js
@@ -28,7 +28,7 @@ export function setupScene(container) {
 
     const mapWidth = 128;
     const mapHeight = 128;
-    const { mesh: mapMesh, obstacles: terrainObstacles, chunkBarrier } = createMap(mapWidth, mapHeight);
+    const { mesh: mapMesh, obstacles: terrainObstacles } = createMap(mapWidth, mapHeight);
     scene.add(mapMesh);
 
     const gridHelper = new THREE.GridHelper(mapWidth, mapWidth, 0xaaaaaa, 0x666666);
@@ -51,5 +51,5 @@ export function setupScene(container) {
     directionalLight.shadow.mapSize.height = 2048;
     scene.add(directionalLight);
 
-    return { scene, camera, renderer, controls, pathfinder, terrainObstacles, mapWidth, mapHeight, gridHelper, chunkBarrier };
+    return { scene, camera, renderer, controls, pathfinder, terrainObstacles, mapWidth, mapHeight, gridHelper };
 }


### PR DESCRIPTION
## Summary
- eliminate the plateau wall that split the starting map
- adjust scene setup for new map return type
- ring the expansion area with plateaus when it spawns

## Testing
- `python3 -m http.server 8000` *(served site and fetched index.html)*

------
https://chatgpt.com/codex/tasks/task_e_6856ff18688c8332ae2027d95c99327f