### PR TITLE
Fix compass orientation bug

### DIFF
--- a/src/game/ui/Compass.js
+++ b/src/game/ui/Compass.js
@@ -25,11 +25,11 @@ export class Compass {
         if (deg >= -45 && deg < 45) {
             orientation = 'N';
         } else if (deg >= 45 && deg < 135) {
-            orientation = 'E';
+            orientation = 'W';
         } else if (deg < -135 || deg >= 135) {
             orientation = 'S';
         } else {
-            orientation = 'W';
+            orientation = 'E';
         }
 
         compassEl.textContent = orientation;


### PR DESCRIPTION
## Summary
- fix compass orientation logic so east and west show correctly

## Testing
- `python3 -m http.server 8000`
- `curl -I http://localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_6857052d896c8332a0f8265a8ed2f326