### PR TITLE
Add Spotify advertisement on M key

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,10 +158,9 @@
     <div id="spotify-modal" class="hidden">
         <div class="spotify-modal-content">
             <button id="close-spotify-modal" class="close-button">&times;</button>
-            <h2>In-Game Jukebox</h2>
-            <p>Your personal soundtrack for conquering the cosmos!</p>
+            <h2>Advertisement Break</h2>
+            <p>Enjoy this featured track while the game resumes shortly.</p>
             <div id="spotify-player-placeholder">
-                <!-- Spotify player would be embedded here -->
                 <p>Spotify Player Placeholder</p>
             </div>
         </div>

--- a/src/game/ui.js
+++ b/src/game/ui.js
@@ -54,9 +54,36 @@ function toggleGrid() {
     }
 }
 
-function toggleSpotifyModal() {
+let adTimeout = null;
+
+function showSpotifyAd() {
     if (!isGameRunning) return;
-    spotifyModal.classList.toggle('hidden');
+
+    const placeholder = document.getElementById('spotify-player-placeholder');
+    if (!placeholder) return;
+
+    spotifyModal.classList.remove('hidden');
+    placeholder.innerHTML =
+        '<iframe id="spotify-ad-iframe" ' +
+        'src="https://open.spotify.com/embed/track/6A9JER2SJiuZbAnYDZmIo2?si=3a3b921b296741a3&autoplay=1" ' +
+        'width="100%" height="80" frameborder="0" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"></iframe>';
+
+    if (adTimeout) {
+        clearTimeout(adTimeout);
+    }
+    adTimeout = setTimeout(hideSpotifyAd, 15000);
+}
+
+function hideSpotifyAd() {
+    const placeholder = document.getElementById('spotify-player-placeholder');
+    if (placeholder) {
+        placeholder.innerHTML = '<p>Spotify Player Placeholder</p>';
+    }
+    spotifyModal.classList.add('hidden');
+    if (adTimeout) {
+        clearTimeout(adTimeout);
+        adTimeout = null;
+    }
 }
 
 function toggleDevLogModal() {
@@ -176,7 +203,7 @@ export function initUI(commandExecutor, startGameCallback, audioManager, getGrid
         sfxVolumeSlider.value = e.target.value;
     });
 
-    closeSpotifyModalButton.addEventListener('click', toggleSpotifyModal);
+    closeSpotifyModalButton.addEventListener('click', hideSpotifyAd);
     closeDevLogModalButton.addEventListener('click', toggleDevLogModal);
     clearDevLogButton.addEventListener('click', () => devLogger.clearLogs());
     closeChangelogModalButton.addEventListener('click', toggleChangelogModal);
@@ -205,7 +232,7 @@ export function initUI(commandExecutor, startGameCallback, audioManager, getGrid
                 togglePause();
                 break;
             case 'KeyM':
-                toggleSpotifyModal();
+                showSpotifyAd();
                 break;
             case 'Backslash':
                 if (devLogger.isActive) {


### PR DESCRIPTION
## Summary
- transform jukebox modal into an advertisement
- show an auto closing Spotify embed when the `M` key is pressed

## Testing
- `python3 -m http.server 8000`
- `curl http://localhost:8000/index.html`

------
https://chatgpt.com/codex/tasks/task_e_6857077045a08332b5960d92da23583c