### PR TITLE
Add audio warnings for resource issues

### DIFF
--- a/src/game/preloader.js
+++ b/src/game/preloader.js
@@ -129,6 +129,13 @@ export async function preloadAssets(audioManager) {
         });
     });
 
+    const warningUrls = {
+        minerals: 'https://file.garden/Zy7B0LkdIVpGyzA1/StarCraft/sounds/Terran/Units/SCV/minerals_warning.wav',
+        gas: 'https://file.garden/Zy7B0LkdIVpGyzA1/StarCraft/sounds/Terran/Units/SCV/gas_warning.wav',
+        supply: 'https://file.garden/Zy7B0LkdIVpGyzA1/StarCraft/sounds/Terran/Units/SCV/supply_warning.wav'
+    };
+    tasks.push(() => audioManager.loadWarningSounds(warningUrls));
+
     const bgUrls = [
         'https://file.garden/Zy7B0LkdIVpGyzA1/StarCraft/sounds/Terran/Terran%20BGM.mp3',
         'https://file.garden/Zy7B0LkdIVpGyzA1/StarCraft/sounds/Terran/Terran%20BGM2.mp3',

--- a/src/game/ui.js
+++ b/src/game/ui.js
@@ -256,6 +256,16 @@ export function updatePlacementText(message) {
 }
 
 export function updateStatusText(message) {
+    const lower = message.toLowerCase();
+    if (audioManagerRef) {
+        if (lower.includes('not enough minerals') && audioManagerRef.mineralsWarningSoundName) {
+            audioManagerRef.playSound(audioManagerRef.mineralsWarningSoundName);
+        } else if (lower.includes('not enough vespene') && audioManagerRef.gasWarningSoundName) {
+            audioManagerRef.playSound(audioManagerRef.gasWarningSoundName);
+        } else if (lower.includes('additional supply required') && audioManagerRef.supplyWarningSoundName) {
+            audioManagerRef.playSound(audioManagerRef.supplyWarningSoundName);
+        }
+    }
     messageDisplay.updateStatusText(message);
 }
 

--- a/src/utils/audio.js
+++ b/src/utils/audio.js
@@ -7,6 +7,9 @@ export class AudioManager {
         this.backgroundTrackNames = [];
         this.scvConstructedSoundNames = [];
         this.scvMark2ConstructedSoundNames = [];
+        this.mineralsWarningSoundName = null;
+        this.gasWarningSoundName = null;
+        this.supplyWarningSoundName = null;
         this.backgroundGain = null;
         this.currentTrackIndex = 0;
         this.backgroundPlaying = false;
@@ -67,6 +70,23 @@ export class AudioManager {
         const index = Math.floor(Math.random() * names.length);
         const name = names[index];
         this.playSound(name);
+    }
+
+    async loadWarningSounds(urls) {
+        const promises = [];
+        if (urls.minerals) {
+            this.mineralsWarningSoundName = 'minerals_warning';
+            promises.push(assetManager.loadSound(urls.minerals, this.mineralsWarningSoundName));
+        }
+        if (urls.gas) {
+            this.gasWarningSoundName = 'gas_warning';
+            promises.push(assetManager.loadSound(urls.gas, this.gasWarningSoundName));
+        }
+        if (urls.supply) {
+            this.supplyWarningSoundName = 'supply_warning';
+            promises.push(assetManager.loadSound(urls.supply, this.supplyWarningSoundName));
+        }
+        await Promise.all(promises);
     }
 
     async loadBackgroundTracks(urls) {


### PR DESCRIPTION
## Summary
- load warning sounds in the preloader
- support warning sound names and loader in `AudioManager`
- play warning sounds when status messages show resource issues

## Testing
- `python3 -m http.server 8000` then `curl -I http://localhost:8000/index.html`

------
https://chatgpt.com/codex/tasks/task_e_68570ba8bb8c8332a49a3192385e9f5e