### PR TITLE
Implement Physics Lab research

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,5 @@
 - Documented in `AGENTS.md` that all contributions must update this changelog.
 - Explained in `AGENTS.md` how remote sound URLs in `preloader.js` are loaded and registered.
 - Control Tower can research flight upgrades.
+- Physics Lab enables Battlecruiser upgrades.
 

--- a/src/buildings/physics-lab.js
+++ b/src/buildings/physics-lab.js
@@ -12,7 +12,8 @@ export class PhysicsLab {
         this.parentBuilding = parent;
         this.isAddon = true;
 
-        this.commands = []; // Research commands will go here.
+        this.buildQueue = []; // For research progress
+        this.commands = []; // Research commands will be populated
 
         this.mesh = this.createMesh();
         this.mesh.position.copy(position);
@@ -79,19 +80,97 @@ export class PhysicsLab {
         this.selected = true; 
         if(this.parentBuilding && !this.parentBuilding.selected) this.parentBuilding.select();
     }
-    deselect(flag) { 
+    deselect(flag) {
         this.selected = false;
         if(this.parentBuilding && this.parentBuilding.selected && !flag) this.parentBuilding.deselect(true);
     }
-    
-    executeCommand(commandName, gameState, statusCallback) {
-        // Research logic for Battlecruiser upgrades would go here
+
+    updateCommands(gameState) {
+        if (this.isUnderConstruction || this.buildQueue.length > 0) {
+            this.commands = [];
+            return;
+        }
+
+        const newCommands = new Array(12).fill(null);
+
+        if (!gameState.upgrades.yamatoGun) {
+            newCommands[0] = {
+                command: 'research_yamato_gun',
+                hotkey: 'Y',
+                icon: 'assets/images/yamato_cannon_icon.png',
+                name: 'Research Yamato Gun',
+                cost: { minerals: 100, vespene: 100 },
+                researchTime: 80,
+            };
+        }
+
+        if (!gameState.upgrades.behemothReactor) {
+            newCommands[1] = {
+                command: 'research_behemoth_reactor',
+                hotkey: 'B',
+                icon: 'assets/images/train_battlecruiser_icon.png',
+                name: 'Research Behemoth Reactor',
+                cost: { minerals: 150, vespene: 150 },
+                researchTime: 80,
+            };
+        }
+
+        this.commands = newCommands;
     }
 
-    update(delta) {
+    executeCommand(commandName, gameState, statusCallback) {
+        const command = this.commands.find(c => c && c.command === commandName);
+        if (!command) return;
+
+        if (commandName.startsWith('research_')) {
+            if (this.buildQueue.length > 0) {
+                statusCallback('Already researching an upgrade.');
+                return true;
+            }
+            if (gameState.minerals < command.cost.minerals || (command.cost.vespene && gameState.vespene < command.cost.vespene)) {
+                statusCallback('Not enough resources.');
+                return true;
+            }
+
+            gameState.minerals -= command.cost.minerals;
+            if (command.cost.vespene) gameState.vespene -= command.cost.vespene;
+
+            this.buildQueue.push({
+                type: command.name,
+                buildTime: command.researchTime,
+                progress: 0,
+                originalCommand: commandName,
+            });
+
+            statusCallback(`Researching ${command.name}...`);
+            this.updateCommands(gameState);
+            return true;
+        }
+    }
+
+    update(delta, gameState) {
         if(this.electronPaths) {
             this.electronPaths.rotation.y += delta * 0.5;
             this.electronPaths.rotation.x += delta * 0.2;
+        }
+
+        if (this.buildQueue.length > 0) {
+            const research = this.buildQueue[0];
+            research.progress += delta;
+
+            if (research.progress >= research.buildTime) {
+                const finished = this.buildQueue.shift();
+                if (finished.originalCommand.includes('yamato_gun')) {
+                    gameState.upgrades.yamatoGun = true;
+                } else if (finished.originalCommand.includes('behemoth_reactor')) {
+                    gameState.upgrades.behemothReactor = true;
+                }
+                this.updateCommands(gameState);
+            }
+        }
+
+        if (this.buildQueue.length === 0) {
+            this.updateCommands(gameState);
         }
     }
 }

--- a/src/game/gameState.js
+++ b/src/game/gameState.js
@@ -17,6 +17,8 @@ export const gameState = {
         empShockwave: false,
         wraithCloaking: false,
         dropThrusters: false,
+        yamatoGun: false,
+        behemothReactor: false,
     },
     academyBuilt: false,
     engineeringBayBuilt: false,


### PR DESCRIPTION
## Summary
- add Yamato Gun and Behemoth Reactor flags to `gameState`
- enable researching Battlecruiser upgrades in Physics Lab
- document new capability in README

## Testing
- `python3 -m http.server 8000` *(fails: no output when starting server)*

------
https://chatgpt.com/codex/tasks/task_e_6857117afc148332bc2fb093a84d29c0