### PR TITLE
Implement Nuclear Silo arming

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,5 @@
 - Explained in `AGENTS.md` how remote sound URLs in `preloader.js` are loaded and registered.
 - Control Tower can research flight upgrades.
 - Physics Lab enables Battlecruiser upgrades.
+- Nuclear Silo can arm nuclear missiles over time.
 


### PR DESCRIPTION
## Summary
- implement resource consumption and progress tracking for `arm_nuke`
- finish nuke arming in `update`
- document nuke arming in changelog

## Testing
- `python3 -m http.server 8000`
- `curl -I http://localhost:8000/index.html`

------
https://chatgpt.com/codex/tasks/task_e_6857132a003883329167c281529e9e0e