### PR TITLE
Add SCV build/repair commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,5 @@
 - Nuclear Silo can arm nuclear missiles over time.
 - Comsat Station's scanner sweep now consumes energy and reveals terrain.
 - Armory can research vehicle and ship weapon/armor upgrades.
+- SCV can now construct basic buildings and repair damaged allies.
 


### PR DESCRIPTION
## Summary
- extend SCV with dynamic command card similar to SCV Mark 2
- implement build and repair behavior
- allow SCVs to repair via right-click
- document SCV improvements in the changelog

## Testing
- `python3 -m http.server 8000` *(fails: no output due to server running in background)*

------
https://chatgpt.com/codex/tasks/task_e_685716cb541083328f50c126494b3d4f