### PR TITLE
Add Ghost abilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,5 @@
 - Armory can research vehicle and ship weapon/armor upgrades.
 - SCV can now construct basic buildings and repair damaged allies.
 - Medics can heal wounded infantry at the cost of energy.
+- Ghosts can cloak, use Lockdown and call Nuclear Strikes when a loaded Nuclear Silo is available.
 


### PR DESCRIPTION
## Summary
- implement Ghost cloak, lockdown and nuke strike abilities
- drain energy while cloaked and regenerate when visible
- nuke strike requires an armed Nuclear Silo
- document Ghost functionality in the changelog

## Testing
- `python3 -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_6857197937148332accd2d78b642e3ca