### PR TITLE
Add Yamato Cannon ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,5 @@
 - Medics can heal wounded infantry at the cost of energy.
 - Ghosts can cloak, use Lockdown and call Nuclear Strikes when a loaded Nuclear Silo is available.
 - Science Vessels can deploy Defensive Matrix, EMP Shockwave and Irradiate abilities.
+- Battlecruisers can fire the Yamato Cannon when researched, consuming energy and displaying a blast effect.
 

--- a/src/game/effects.js
+++ b/src/game/effects.js
@@ -69,6 +69,20 @@ export function createIrradiate(position) {
     activeEffects.push({ mesh: irradiate, life: 3, initialLife: 3 });
 }
 
+export function createYamatoBlast(start, target) {
+    const material = new THREE.LineBasicMaterial({
+        color: 0xff4500,
+        transparent: true,
+        opacity: 0.8,
+        blending: THREE.AdditiveBlending,
+    });
+    const points = [start.clone(), target.clone()];
+    const geometry = new THREE.BufferGeometry().setFromPoints(points);
+    const beam = new THREE.Line(geometry, material);
+    scene.add(beam);
+    activeEffects.push({ mesh: beam, life: 0.5, initialLife: 0.5 });
+}
+
 export function updateGatheringEffects(units) {
     const activeUnits = new Set(units);
 

--- a/src/units/battlecruiser.js
+++ b/src/units/battlecruiser.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { assetManager } from '../utils/asset-manager.js';
+import { createYamatoBlast } from '../game/effects.js';
 
 export class Battlecruiser {
     constructor(position) {
@@ -133,7 +134,21 @@ export class Battlecruiser {
 
     executeCommand(commandName, gameState, statusCallback) {
         if (commandName === 'yamato_cannon') {
-            statusCallback("Yamato Cannon not yet implemented.");
+            if (!gameState.upgrades.yamatoGun) {
+                statusCallback('Yamato Cannon not researched.');
+                return;
+            }
+            if (this.energy < 150) {
+                statusCallback('Not enough energy.');
+                return;
+            }
+            this.energy -= 150;
+            const start = this.mesh.position.clone();
+            start.y += 2;
+            const forward = new THREE.Vector3(0, 0, -1).applyQuaternion(this.mesh.quaternion).normalize();
+            const target = start.clone().add(forward.multiplyScalar(20));
+            createYamatoBlast(start, target);
+            statusCallback('Firing Yamato Cannon!');
         }
     }
 


### PR DESCRIPTION
## Summary
- enable research-dependent Yamato Cannon on Battlecruisers
- show a short orange beam effect for the blast
- document the new feature in the changelog

## Testing
- `python3 -m http.server 8000` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68571f18da10833284390ea374b4e234