### PR TITLE
Improve map expansion via world module

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,5 @@
 - Ghosts can cloak, use Lockdown and call Nuclear Strikes when a loaded Nuclear Silo is available.
 - Science Vessels can deploy Defensive Matrix, EMP Shockwave and Irradiate abilities.
 - Battlecruisers can fire the Yamato Cannon when researched, consuming energy and displaying a blast effect.
+- Unlocking a Factory now expands the map using a new world module and populates the new area with resources.
 

--- a/src/game/index.js
+++ b/src/game/index.js
@@ -7,7 +7,6 @@ import { initLoop } from './loop.js';
 import { gameState } from './gameState.js';
 import { setupControls, getSelectedObjects } from './controls.js';
 import { AudioManager } from '../utils/audio.js';
-import { assetManager } from '../utils/asset-manager.js';
 import { initUI, updateStatusText, updatePlacementText, hideStartScreen, setGameRunning, isPaused, isGameRunning } from './ui.js';
 import { init as initMinimap, setMapSize as setMinimapSize } from './minimap.js';
 import { preloadAssets } from './preloader.js';
@@ -17,7 +16,7 @@ import { initMobileControls } from './mobileControls.js';
 import { devLogger } from '../utils/dev-logger.js';
 import { setupInitialState } from './initial-state.js';
 import { setPathfinder as setRCHPathfinder } from './rightClickHandler.js';
-import { Pathfinder } from '../utils/pathfinding.js';
+import { World } from './world.js';
 
 let scene, camera, renderer, controls, pathfinder, terrainObstacles, gridHelper;
 let mapWidth, mapHeight;
@@ -28,75 +27,11 @@ let mineralFields = [];
 let vespeneGeysers = [];
 let selectables = [];
 let collidableObjects = [];
+let world;
 const audioManager = new AudioManager();
 const keyState = {};
 let gameContainer;
 let devModeActive = false;
-
-function openMapChunk() {
-
-    const groundTexture = assetManager.get('ground');
-    groundTexture.wrapS = groundTexture.wrapT = THREE.RepeatWrapping;
-    groundTexture.repeat.set(mapWidth / 4, mapHeight / 4);
-    const material = new THREE.MeshStandardMaterial({
-        map: groundTexture,
-        metalness: 0.1,
-        roughness: 0.9,
-    });
-    const geometry = new THREE.PlaneGeometry(mapWidth, mapHeight);
-    const newGround = new THREE.Mesh(geometry, material);
-    newGround.rotation.x = -Math.PI / 2;
-    newGround.receiveShadow = true;
-    newGround.name = 'ground';
-    newGround.position.set(mapWidth, 0, 0);
-    scene.add(newGround);
-
-    const borderSize = 10;
-    const plateauHeight = 2;
-    function addBorderPlateau(x, z, sizeX, sizeZ) {
-        const plateauGeom = new THREE.BoxGeometry(sizeX, plateauHeight, sizeZ);
-        const plateau = new THREE.Mesh(plateauGeom, material);
-        plateau.position.set(x, plateauHeight / 2, z);
-        plateau.castShadow = true;
-        plateau.receiveShadow = true;
-        scene.add(plateau);
-
-        const minX = x - sizeX / 2;
-        const maxX = x + sizeX / 2;
-        const minZ = z - sizeZ / 2;
-        const maxZ = z + sizeZ / 2;
-        const obstacle = {
-            collider: new THREE.Box3(
-                new THREE.Vector3(minX, 0, minZ),
-                new THREE.Vector3(maxX, plateauHeight, maxZ)
-            ),
-            getCollider() { return this.collider; }
-        };
-        terrainObstacles.push(obstacle);
-        collidableObjects.push(obstacle);
-    }
-
-    const baseX = mapWidth;
-    const northZ = mapHeight / 2 - borderSize / 2;
-    const southZ = -mapHeight / 2 + borderSize / 2;
-    const eastX = baseX + mapWidth / 2 - borderSize / 2;
-
-    addBorderPlateau(baseX, northZ, mapWidth, borderSize);
-    addBorderPlateau(baseX, southZ, mapWidth, borderSize);
-    addBorderPlateau(eastX, 0, borderSize, mapHeight - 2 * borderSize);
-
-    gameState.mapChunksUnlocked += 1;
-
-    const newWidth = mapWidth * (gameState.mapChunksUnlocked + 1);
-    pathfinder = new Pathfinder(newWidth, mapHeight, 1);
-    window.pathfinder = pathfinder;
-    setSpawnerPathfinder(pathfinder);
-    setPlacementPathfinder(pathfinder);
-    setRCHPathfinder(pathfinder);
-    if (loopDeps) loopDeps.pathfinder = pathfinder;
-    pathfinder.updateObstacles(collidableObjects);
-    setMinimapSize(newWidth, mapHeight);
-}
 
 function init() {
     gameContainer = document.getElementById('game-container');
@@ -149,7 +84,17 @@ async function startGame() {
     gridHelper = sceneData.gridHelper;
     mapWidth = sceneData.mapWidth;
     mapHeight = sceneData.mapHeight;
-    gameState.onFactoryBuilt = openMapChunk;
+    world = new World(scene, mapWidth, mapHeight, pathfinder, collidableObjects, terrainObstacles);
+    gameState.onFactoryBuilt = () => {
+        const result = world.unlockNextChunk();
+        pathfinder = world.pathfinder;
+        window.pathfinder = pathfinder;
+        setSpawnerPathfinder(pathfinder);
+        setPlacementPathfinder(pathfinder);
+        setRCHPathfinder(pathfinder);
+        if (loopDeps) loopDeps.pathfinder = pathfinder;
+        setMinimapSize(result.width, mapHeight);
+    };
 
     initSpawner({ scene, units, buildings, selectables, collidableObjects, pathfinder, gameState, audioManager });
     initEffects(scene);

--- a/src/game/world.js
+++ b/src/game/world.js
@@ -1,0 +1,102 @@
+import * as THREE from 'three';
+import { assetManager } from '../utils/asset-manager.js';
+import { Pathfinder } from '../utils/pathfinding.js';
+import { MineralField } from '../resources/mineral-field.js';
+import { VespeneGeyser } from '../resources/vespene-geyser.js';
+
+export class World {
+    constructor(scene, width, height, pathfinder, collidableObjects, terrainObstacles) {
+        this.scene = scene;
+        this.chunkWidth = width;
+        this.height = height;
+        this.pathfinder = pathfinder;
+        this.collidableObjects = collidableObjects;
+        this.terrainObstacles = terrainObstacles;
+        this.chunks = 1;
+    }
+
+    unlockNextChunk() {
+        const { chunkWidth, height, scene } = this;
+        const baseX = chunkWidth * this.chunks;
+        const groundTexture = assetManager.get('ground');
+        groundTexture.wrapS = groundTexture.wrapT = THREE.RepeatWrapping;
+        groundTexture.repeat.set(chunkWidth / 4, height / 4);
+        const material = new THREE.MeshStandardMaterial({
+            map: groundTexture,
+            metalness: 0.1,
+            roughness: 0.9,
+        });
+        const geometry = new THREE.PlaneGeometry(chunkWidth, height);
+        const newGround = new THREE.Mesh(geometry, material);
+        newGround.rotation.x = -Math.PI / 2;
+        newGround.receiveShadow = true;
+        newGround.name = 'ground';
+        newGround.position.set(baseX, 0, 0);
+        scene.add(newGround);
+
+        const borderSize = 10;
+        const plateauHeight = 2;
+        const addBorderPlateau = (x, z, sizeX, sizeZ) => {
+            const plateauGeom = new THREE.BoxGeometry(sizeX, plateauHeight, sizeZ);
+            const plateau = new THREE.Mesh(plateauGeom, material);
+            plateau.position.set(x, plateauHeight / 2, z);
+            plateau.castShadow = true;
+            plateau.receiveShadow = true;
+            scene.add(plateau);
+
+            const minX = x - sizeX / 2;
+            const maxX = x + sizeX / 2;
+            const minZ = z - sizeZ / 2;
+            const maxZ = z + sizeZ / 2;
+            const obstacle = {
+                collider: new THREE.Box3(
+                    new THREE.Vector3(minX, 0, minZ),
+                    new THREE.Vector3(maxX, plateauHeight, maxZ)
+                ),
+                getCollider() { return this.collider; }
+            };
+            this.terrainObstacles.push(obstacle);
+            this.collidableObjects.push(obstacle);
+        };
+
+        const northZ = height / 2 - borderSize / 2;
+        const southZ = -height / 2 + borderSize / 2;
+        const eastX = baseX + chunkWidth / 2 - borderSize / 2;
+
+        addBorderPlateau(baseX, northZ, chunkWidth, borderSize);
+        addBorderPlateau(baseX, southZ, chunkWidth, borderSize);
+        addBorderPlateau(eastX, 0, borderSize, height - 2 * borderSize);
+
+        // Spawn resources in the new chunk
+        const resources = [];
+        for (let i = 0; i < 4; i++) {
+            const pos = new THREE.Vector3(
+                baseX - chunkWidth / 2 + 20 + Math.random() * (chunkWidth - 40),
+                0,
+                -height / 2 + 20 + Math.random() * (height - 40)
+            );
+            const field = new MineralField(pos);
+            scene.add(field.mesh);
+            resources.push(field);
+            this.collidableObjects.push(field);
+        }
+
+        const geyserPos = new THREE.Vector3(
+            baseX - chunkWidth / 2 + 20 + Math.random() * (chunkWidth - 40),
+            0,
+            0
+        );
+        const geyser = new VespeneGeyser(geyserPos);
+        scene.add(geyser.mesh);
+        resources.push(geyser);
+        this.collidableObjects.push(geyser);
+
+        this.chunks += 1;
+
+        const newWidth = chunkWidth * this.chunks;
+        this.pathfinder = new Pathfinder(newWidth, height, 1);
+        this.pathfinder.updateObstacles(this.collidableObjects);
+
+        return { width: newWidth, resources };
+    }
+}


### PR DESCRIPTION
## Summary
- implement `World` class for managing map chunks
- expand the map when a Factory is built, spawning minerals and a geyser
- hook new world module into game initialization
- document new feature in the changelog

## Testing
- `python3 -m http.server 8000`
- `curl -s http://localhost:8000/index.html | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68572b4d8bcc8332a411981be8f45a70