### PR TITLE
Extend Spotify ad duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,5 @@
 - Ghosts can cloak, use Lockdown and call Nuclear Strikes when a loaded Nuclear Silo is available.
 - Science Vessels can deploy Defensive Matrix, EMP Shockwave and Irradiate abilities.
 - Battlecruisers can fire the Yamato Cannon when researched, consuming energy and displaying a blast effect.
+- Spotify advertisement now plays for a full 30 seconds before closing.
 

--- a/src/game/ui.js
+++ b/src/game/ui.js
@@ -71,7 +71,8 @@ function showSpotifyAd() {
     if (adTimeout) {
         clearTimeout(adTimeout);
     }
-    adTimeout = setTimeout(hideSpotifyAd, 15000);
+    // Display the ad for 30 seconds before hiding
+    adTimeout = setTimeout(hideSpotifyAd, 30000);
 }
 
 function hideSpotifyAd() {


### PR DESCRIPTION
## Summary
- keep Spotify advertisement on screen for 30 seconds
- document the new ad length in the changelog

## Testing
- `python3 -m http.server 8000`
- `curl -I http://localhost:8000/index.html`

------
https://chatgpt.com/codex/tasks/task_e_6858165db1948332a90790f3d776c838