### PR TITLE
Replace Spotify advertisement with YouTube video

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,5 @@
 - Science Vessels can deploy Defensive Matrix, EMP Shockwave and Irradiate abilities.
 - Battlecruisers can fire the Yamato Cannon when researched, consuming energy and displaying a blast effect.
 - Spotify advertisement now plays for a full 30 seconds before closing.
+- In-game advertisement now shows a YouTube video instead of a Spotify track.
 

--- a/assets/css/modals.css
+++ b/assets/css/modals.css
@@ -25,7 +25,7 @@
 
 .spotify-modal-content h2 {
     margin-top: 0;
-    color: #1DB954; /* Spotify Green */
+    color: #FF0000; /* YouTube Red */
 }
 
 .spotify-modal-content p {
@@ -70,7 +70,7 @@
     width: 100%;
     height: 100%;
     background-color: rgba(0,0,0,0.75);
-    z-index: 1002; /* Above spotify modal */
+    z-index: 1002; /* Above video modal */
     display: flex;
     justify-content: center;
     align-items: center;

--- a/index.html
+++ b/index.html
@@ -159,9 +159,9 @@
         <div class="spotify-modal-content">
             <button id="close-spotify-modal" class="close-button">&times;</button>
             <h2>Advertisement Break</h2>
-            <p>Enjoy this featured track while the game resumes shortly.</p>
+            <p>Enjoy this short video while the game resumes shortly.</p>
             <div id="spotify-player-placeholder">
-                <p>Spotify Player Placeholder</p>
+                <p>Video Player Placeholder</p>
             </div>
         </div>
     </div>

--- a/src/game/ui.js
+++ b/src/game/ui.js
@@ -56,7 +56,7 @@ function toggleGrid() {
 
 let adTimeout = null;
 
-function showSpotifyAd() {
+function showVideoAd() {
     if (!isGameRunning) return;
 
     const placeholder = document.getElementById('spotify-player-placeholder');
@@ -64,21 +64,21 @@ function showSpotifyAd() {
 
     spotifyModal.classList.remove('hidden');
     placeholder.innerHTML =
-        '<iframe id="spotify-ad-iframe" ' +
-        'src="https://open.spotify.com/embed/track/6A9JER2SJiuZbAnYDZmIo2?si=3a3b921b296741a3&autoplay=1" ' +
-        'width="100%" height="80" frameborder="0" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"></iframe>';
+        '<iframe id="video-ad-iframe" ' +
+        'src="https://www.youtube.com/embed/mQgRLL3wod0?autoplay=1" ' +
+        'width="100%" height="200" frameborder="0" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"></iframe>';
 
     if (adTimeout) {
         clearTimeout(adTimeout);
     }
     // Display the ad for 30 seconds before hiding
-    adTimeout = setTimeout(hideSpotifyAd, 30000);
+    adTimeout = setTimeout(hideVideoAd, 30000);
 }
 
-function hideSpotifyAd() {
+function hideVideoAd() {
     const placeholder = document.getElementById('spotify-player-placeholder');
     if (placeholder) {
-        placeholder.innerHTML = '<p>Spotify Player Placeholder</p>';
+        placeholder.innerHTML = '<p>Video Player Placeholder</p>';
     }
     spotifyModal.classList.add('hidden');
     if (adTimeout) {
@@ -204,7 +204,7 @@ export function initUI(commandExecutor, startGameCallback, audioManager, getGrid
         sfxVolumeSlider.value = e.target.value;
     });
 
-    closeSpotifyModalButton.addEventListener('click', hideSpotifyAd);
+    closeSpotifyModalButton.addEventListener('click', hideVideoAd);
     closeDevLogModalButton.addEventListener('click', toggleDevLogModal);
     clearDevLogButton.addEventListener('click', () => devLogger.clearLogs());
     closeChangelogModalButton.addEventListener('click', toggleChangelogModal);
@@ -233,7 +233,7 @@ export function initUI(commandExecutor, startGameCallback, audioManager, getGrid
                 togglePause();
                 break;
             case 'KeyM':
-                showSpotifyAd();
+                showVideoAd();
                 break;
             case 'Backslash':
                 if (devLogger.isActive) {


### PR DESCRIPTION
## Summary
- tweak advertisement modal text and placeholder
- switch ad embed to YouTube video
- adjust modal styling for new video content
- update controls to show the video ad
- note change in changelog

## Testing
- `python3 -m http.server 8000` *(fails: no output but process running)*

------
https://chatgpt.com/codex/tasks/task_e_68583b3357288332ac7c8d0d4ade4f92