### PR TITLE
Pause bgm during ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,5 @@
 - Battlecruisers can fire the Yamato Cannon when researched, consuming energy and displaying a blast effect.
 - Spotify advertisement now plays for a full 30 seconds before closing.
 - In-game advertisement now shows a YouTube video instead of a Spotify track.
+- Background music pauses while the advertisement video plays.
 

--- a/src/game/ui.js
+++ b/src/game/ui.js
@@ -62,6 +62,10 @@ function showVideoAd() {
     const placeholder = document.getElementById('spotify-player-placeholder');
     if (!placeholder) return;
 
+    if (audioManagerRef) {
+        audioManagerRef.pauseBackgroundMusic();
+    }
+
     spotifyModal.classList.remove('hidden');
     placeholder.innerHTML =
         '<iframe id="video-ad-iframe" ' +
@@ -81,6 +85,9 @@ function hideVideoAd() {
         placeholder.innerHTML = '<p>Video Player Placeholder</p>';
     }
     spotifyModal.classList.add('hidden');
+    if (audioManagerRef) {
+        audioManagerRef.resumeBackgroundMusic();
+    }
     if (adTimeout) {
         clearTimeout(adTimeout);
         adTimeout = null;

--- a/src/utils/audio.js
+++ b/src/utils/audio.js
@@ -158,4 +158,22 @@ export class AudioManager {
 
         playNext();
     }
+
+    pauseBackgroundMusic() {
+        if (!this.backgroundPlaying) return;
+        this.backgroundPlaying = false;
+        if (this.backgroundSource) {
+            try {
+                this.backgroundSource.onended = null;
+                this.backgroundSource.stop();
+                this.backgroundSource.disconnect();
+            } catch (e) { /* ignore errors if already stopped */ }
+            this.backgroundSource = null;
+        }
+    }
+
+    resumeBackgroundMusic() {
+        if (this.backgroundPlaying) return;
+        this.playBackgroundMusic();
+    }
 }


### PR DESCRIPTION
## Summary
- pause/resume background music around ad video playback
- expose pause/resume methods on `AudioManager`
- document the new behaviour in the changelog

## Testing
- `python3 -m http.server 8000` *(manual)*
- `curl -sSf http://localhost:8000/index.html`

------
https://chatgpt.com/codex/tasks/task_e_685842bb6cdc8332ad4d59326b67d25b