### PR TITLE
Fix video panel alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,5 @@
 - In-game advertisement now shows a YouTube video instead of a Spotify track.
 - Background music pauses while the advertisement video plays.
 - Added a placeholder video panel beside the status messages for future cutscenes.
+- Fixed the video panel so it stays anchored to the status text box.
 

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -110,10 +110,11 @@ canvas {
 
 #unit-info-container {
     display: flex;
-    justify-content: center;
+    justify-content: flex-start;
     align-items: center;
     gap: 8px;
     padding-bottom: 8px;
+    flex-grow: 1;
 }
 
 #unit-portrait-panel {
@@ -321,6 +322,7 @@ canvas {
     display: flex;
     justify-content: center;
     align-items: center;
+    margin-left: auto;
 }
 
 #status-text-panel-container {


### PR DESCRIPTION
## Summary
- anchor the video panel to the status text box so it doesn't shift
- document the fix in the changelog

## Testing
- `python3 -m http.server 8000`
- `curl -I http://localhost:8000/index.html`

------
https://chatgpt.com/codex/tasks/task_e_6858473affc0833280d3c141129228b8