### PR TITLE
Add ramped border plateaus

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,5 @@
 - Added a placeholder video panel beside the status messages for future cutscenes.
 - Fixed the video panel so it stays anchored to the status text box.
 - Map expansion logic now positions new ground based on the number of unlocked chunks, keeping pathfinding and the minimap consistent.
+- Border plateaus can now include optional ramps so elevations vary across new map chunks.
 

--- a/src/game/index.js
+++ b/src/game/index.js
@@ -54,13 +54,62 @@ function openMapChunk() {
 
     const borderSize = 10;
     const plateauHeight = 2;
-    function addBorderPlateau(x, z, sizeX, sizeZ) {
+
+    function createRampGeometry(width, length, height) {
+        const geometry = new THREE.BufferGeometry();
+        const vertices = new Float32Array([
+            -width / 2, height, 0,
+             width / 2, height, 0,
+            -width / 2, 0, -length,
+             width / 2, 0, -length,
+        ]);
+        geometry.setIndex([0, 2, 1, 2, 3, 1]);
+        geometry.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
+        geometry.computeVertexNormals();
+        return geometry;
+    }
+
+    function addBorderPlateau(x, z, sizeX, sizeZ, orientation, withRamp = false) {
         const plateauGeom = new THREE.BoxGeometry(sizeX, plateauHeight, sizeZ);
         const plateau = new THREE.Mesh(plateauGeom, material);
         plateau.position.set(x, plateauHeight / 2, z);
         plateau.castShadow = true;
         plateau.receiveShadow = true;
         scene.add(plateau);
+
+        if (withRamp) {
+            const rampLength = 6;
+            const rampGeom = createRampGeometry(
+                orientation === 'north' || orientation === 'south' ? sizeX : sizeZ,
+                rampLength,
+                plateauHeight
+            );
+            const ramp = new THREE.Mesh(rampGeom, material);
+            ramp.name = 'ground';
+            switch (orientation) {
+                case 'north':
+                    ramp.rotation.y = 0;
+                    ramp.position.set(x, 0, z - sizeZ / 2 - rampLength / 2);
+                    break;
+                case 'south':
+                    ramp.rotation.y = Math.PI;
+                    ramp.position.set(x, 0, z + sizeZ / 2 + rampLength / 2);
+                    break;
+                case 'east':
+                    ramp.rotation.y = -Math.PI / 2;
+                    ramp.position.set(x + sizeX / 2 + rampLength / 2, 0, z);
+                    break;
+                case 'west':
+                    ramp.rotation.y = Math.PI / 2;
+                    ramp.position.set(x - sizeX / 2 - rampLength / 2, 0, z);
+                    break;
+                default:
+                    break;
+            }
+            ramp.castShadow = true;
+            ramp.receiveShadow = true;
+            scene.add(ramp);
+        }
 
         const minX = x - sizeX / 2;
         const maxX = x + sizeX / 2;
@@ -81,9 +130,9 @@ function openMapChunk() {
     const southZ = -mapHeight / 2 + borderSize / 2;
     const eastX = baseX + mapWidth / 2 - borderSize / 2;
 
-    addBorderPlateau(baseX, northZ, mapWidth, borderSize);
-    addBorderPlateau(baseX, southZ, mapWidth, borderSize);
-    addBorderPlateau(eastX, 0, borderSize, mapHeight - 2 * borderSize);
+    addBorderPlateau(baseX, northZ, mapWidth, borderSize, 'north', true);
+    addBorderPlateau(baseX, southZ, mapWidth, borderSize, 'south', true);
+    addBorderPlateau(eastX, 0, borderSize, mapHeight - 2 * borderSize, 'east');
 
     gameState.mapChunksUnlocked += 1;
 

--- a/src/game/map.js
+++ b/src/game/map.js
@@ -69,13 +69,61 @@ export function createMap(width, height) {
     const borderSize = 10;
     const plateauHeight = 2;
 
-    function addBorderPlateau(x, z, sizeX, sizeZ) {
+    function createRampGeometry(width, length, height) {
+        const geometry = new THREE.BufferGeometry();
+        const vertices = new Float32Array([
+            -width / 2, height, 0,
+             width / 2, height, 0,
+            -width / 2, 0, -length,
+             width / 2, 0, -length,
+        ]);
+        geometry.setIndex([0, 2, 1, 2, 3, 1]);
+        geometry.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
+        geometry.computeVertexNormals();
+        return geometry;
+    }
+
+    function addBorderPlateau(x, z, sizeX, sizeZ, orientation, withRamp = false) {
         const plateauGeom = new THREE.BoxGeometry(sizeX, plateauHeight, sizeZ);
         const plateau = new THREE.Mesh(plateauGeom, material);
         plateau.position.set(x, plateauHeight / 2, z);
         plateau.castShadow = true;
         plateau.receiveShadow = true;
         group.add(plateau);
+
+        if (withRamp) {
+            const rampLength = 6;
+            const rampGeom = createRampGeometry(
+                orientation === 'north' || orientation === 'south' ? sizeX : sizeZ,
+                rampLength,
+                plateauHeight
+            );
+            const ramp = new THREE.Mesh(rampGeom, material);
+            ramp.name = 'ground';
+            switch (orientation) {
+                case 'north':
+                    ramp.rotation.y = 0;
+                    ramp.position.set(x, 0, z - sizeZ / 2 - rampLength / 2);
+                    break;
+                case 'south':
+                    ramp.rotation.y = Math.PI;
+                    ramp.position.set(x, 0, z + sizeZ / 2 + rampLength / 2);
+                    break;
+                case 'east':
+                    ramp.rotation.y = -Math.PI / 2;
+                    ramp.position.set(x + sizeX / 2 + rampLength / 2, 0, z);
+                    break;
+                case 'west':
+                    ramp.rotation.y = Math.PI / 2;
+                    ramp.position.set(x - sizeX / 2 - rampLength / 2, 0, z);
+                    break;
+                default:
+                    break;
+            }
+            ramp.castShadow = true;
+            ramp.receiveShadow = true;
+            group.add(ramp);
+        }
 
         const minX = x - sizeX / 2;
         const maxX = x + sizeX / 2;
@@ -95,9 +143,9 @@ export function createMap(width, height) {
     const westX = -width / 2 + borderSize / 2;
     const eastX = width / 2 - borderSize / 2;
 
-    addBorderPlateau(0, northZ, width, borderSize);
-    addBorderPlateau(0, southZ, width, borderSize);
-    addBorderPlateau(westX, 0, borderSize, height - 2 * borderSize);
+    addBorderPlateau(0, northZ, width, borderSize, 'north', true);
+    addBorderPlateau(0, southZ, width, borderSize, 'south', true);
+    addBorderPlateau(westX, 0, borderSize, height - 2 * borderSize, 'west');
     // The eastern edge will be left open for future expansion
 
     return { mesh: group, obstacles };


### PR DESCRIPTION
## Summary
- allow map border plateaus to optionally spawn a sloped ramp
- support the same behavior when new map chunks unlock
- document the change in the changelog

## Testing
- `python3 -m http.server 8000` *(fails: no browser in this environment)*
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68584b8a23ac83329bacad00bfacf435