### PR TITLE
Fix mineral field repair crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,6 @@
 - Map expansion logic now positions new ground based on the number of unlocked chunks, keeping pathfinding and the minimap consistent.
 - Border plateaus can now include optional ramps so elevations vary across new map chunks.
 - Plateau generation was moved to a reusable helper to avoid duplicate logic.
+- Fixed a crash when SCVs attempted to repair mineral fields by excluding
+  resources from repair commands.
 

--- a/src/game/rightClickHandler.js
+++ b/src/game/rightClickHandler.js
@@ -160,7 +160,13 @@ export function handleRightClick(event) {
         }
 
         const repairers = selectedObjects.filter(obj => obj instanceof SCVMark2 || obj instanceof SCV);
-        if (repairers.length > 0 && clickedObject?.currentHealth !== undefined && !clickedObject.isUnderConstruction && clickedObject.currentHealth < clickedObject.maxHealth) {
+        const canRepair = repairers.length > 0 &&
+            clickedObject?.currentHealth !== undefined &&
+            !clickedObject.isUnderConstruction &&
+            clickedObject.currentHealth < clickedObject.maxHealth &&
+            !(clickedObject instanceof MineralField) &&
+            !(clickedObject instanceof VespeneGeyser);
+        if (canRepair) {
             onMoveSound();
             createMoveIndicator(clickedObject.mesh.position);
             const collider = clickedObject.getCollider();


### PR DESCRIPTION
## Summary
- prevent SCVs from trying to repair resource nodes
- document the crash fix in the changelog

## Testing
- `python3 -m http.server 8000` *(fails: server started but no browser in test env)*

------
https://chatgpt.com/codex/tasks/task_e_685851fd46d08332b5644195f6357910