### PR TITLE
Allow walkable plateaus

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Plateaus with ramps no longer block pathfinding; `createPlateau` gained an `isObstacle` option.
 - Added a changelog modal to view project updates and manual information directly in-game. The changelog content is loaded from this file.
 - Documented in `AGENTS.md` that all contributions must update this changelog.
 - Explained in `AGENTS.md` how remote sound URLs in `preloader.js` are loaded and registered.

--- a/src/game/index.js
+++ b/src/game/index.js
@@ -56,8 +56,8 @@ function openMapChunk() {
     const borderSize = 10;
     const plateauHeight = 2;
 
-    function addBorderPlateau(x, z, sizeX, sizeZ, orientation, withRamp = false) {
-        const { meshes, collider } = createPlateau({
+    function addBorderPlateau(x, z, sizeX, sizeZ, orientation, withRamp = false, isObstacle = true) {
+        const { meshes, colliders } = createPlateau({
             x,
             z,
             sizeX,
@@ -65,20 +65,23 @@ function openMapChunk() {
             height: plateauHeight,
             orientation,
             material,
-            withRamp
+            withRamp,
+            isObstacle
         });
         meshes.forEach(m => scene.add(m));
-        const obstacle = { collider, getCollider() { return this.collider; } };
-        terrainObstacles.push(obstacle);
-        collidableObjects.push(obstacle);
+        colliders.forEach(collider => {
+            const obstacle = { collider, getCollider() { return this.collider; } };
+            terrainObstacles.push(obstacle);
+            collidableObjects.push(obstacle);
+        });
     }
 
     const northZ = mapHeight / 2 - borderSize / 2;
     const southZ = -mapHeight / 2 + borderSize / 2;
     const eastX = baseX + mapWidth / 2 - borderSize / 2;
 
-    addBorderPlateau(baseX, northZ, mapWidth, borderSize, 'north', true);
-    addBorderPlateau(baseX, southZ, mapWidth, borderSize, 'south', true);
+    addBorderPlateau(baseX, northZ, mapWidth, borderSize, 'north', true, false);
+    addBorderPlateau(baseX, southZ, mapWidth, borderSize, 'south', true, false);
     addBorderPlateau(eastX, 0, borderSize, mapHeight - 2 * borderSize, 'east');
 
     gameState.mapChunksUnlocked += 1;

--- a/src/game/map.js
+++ b/src/game/map.js
@@ -70,8 +70,8 @@ export function createMap(width, height) {
     const borderSize = 10;
     const plateauHeight = 2;
 
-    function addBorderPlateau(x, z, sizeX, sizeZ, orientation, withRamp = false) {
-        const { meshes, collider } = createPlateau({
+    function addBorderPlateau(x, z, sizeX, sizeZ, orientation, withRamp = false, isObstacle = true) {
+        const { meshes, colliders } = createPlateau({
             x,
             z,
             sizeX,
@@ -79,10 +79,13 @@ export function createMap(width, height) {
             height: plateauHeight,
             orientation,
             material,
-            withRamp
+            withRamp,
+            isObstacle
         });
         meshes.forEach(m => group.add(m));
-        obstacles.push({ collider, getCollider() { return this.collider; } });
+        colliders.forEach(collider => {
+            obstacles.push({ collider, getCollider() { return this.collider; } });
+        });
     }
 
     const northZ = height / 2 - borderSize / 2;
@@ -90,8 +93,8 @@ export function createMap(width, height) {
     const westX = -width / 2 + borderSize / 2;
     const eastX = width / 2 - borderSize / 2;
 
-    addBorderPlateau(0, northZ, width, borderSize, 'north', true);
-    addBorderPlateau(0, southZ, width, borderSize, 'south', true);
+    addBorderPlateau(0, northZ, width, borderSize, 'north', true, false);
+    addBorderPlateau(0, southZ, width, borderSize, 'south', true, false);
     addBorderPlateau(westX, 0, borderSize, height - 2 * borderSize, 'west');
     // The eastern edge will be left open for future expansion
 

--- a/src/utils/map-utils.js
+++ b/src/utils/map-utils.js
@@ -14,7 +14,7 @@ export function createRampGeometry(width, length, height) {
     return geometry;
 }
 
-export function createPlateau({ x, z, sizeX, sizeZ, height = 2, orientation = 'north', material, withRamp = false }) {
+export function createPlateau({ x, z, sizeX, sizeZ, height = 2, orientation = 'north', material, withRamp = false, isObstacle = true }) {
     const meshes = [];
     const plateauGeom = new THREE.BoxGeometry(sizeX, height, sizeZ);
     const plateau = new THREE.Mesh(plateauGeom, material);
@@ -61,11 +61,37 @@ export function createPlateau({ x, z, sizeX, sizeZ, height = 2, orientation = 'n
     const maxX = x + sizeX / 2;
     const minZ = z - sizeZ / 2;
     const maxZ = z + sizeZ / 2;
-    const collider = new THREE.Box3(
-        new THREE.Vector3(minX, 0, minZ),
-        new THREE.Vector3(maxX, height, maxZ)
-    );
 
-    return { meshes, collider };
+    const colliders = [];
+    if (isObstacle) {
+        colliders.push(new THREE.Box3(
+            new THREE.Vector3(minX, 0, minZ),
+            new THREE.Vector3(maxX, height, maxZ)
+        ));
+    } else {
+        const thickness = 0.5;
+        // North side
+        colliders.push(new THREE.Box3(
+            new THREE.Vector3(minX, 0, maxZ - thickness),
+            new THREE.Vector3(maxX, height, maxZ)
+        ));
+        // South side
+        colliders.push(new THREE.Box3(
+            new THREE.Vector3(minX, 0, minZ),
+            new THREE.Vector3(maxX, height, minZ + thickness)
+        ));
+        // East side
+        colliders.push(new THREE.Box3(
+            new THREE.Vector3(maxX - thickness, 0, minZ),
+            new THREE.Vector3(maxX, height, maxZ)
+        ));
+        // West side
+        colliders.push(new THREE.Box3(
+            new THREE.Vector3(minX, 0, minZ),
+            new THREE.Vector3(minX + thickness, height, maxZ)
+        ));
+    }
+
+    return { meshes, colliders };
 }
 


### PR DESCRIPTION
## Summary
- add `isObstacle` flag to `createPlateau`
- treat ramped plateaus as walkable by default when creating the map
- update map expansion logic to support multiple colliders per plateau
- document new option in the changelog

## Testing
- `python3 -m http.server 8000` and `curl -I http://localhost:8000/index.html`

------
https://chatgpt.com/codex/tasks/task_e_685857dba55c8332be36f9f2f426d46f