### PR TITLE
Fix promo images shifting with options menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,5 @@
 - Plateau generation was moved to a reusable helper to avoid duplicate logic.
 - Fixed a crash when SCVs attempted to repair mineral fields by excluding
   resources from repair commands.
+- Anchored the main menu promo images so they remain fixed when opening the options menu.
 

--- a/assets/css/menu.css
+++ b/assets/css/menu.css
@@ -31,8 +31,9 @@
     height: auto;
     border: none;
     position: absolute;
+    top: 50%;
     left: calc(50% + 250px); /* Position it to the right of the centered menu */
-    transform: rotate(-30deg);
+    transform: translateY(-50%) rotate(-30deg);
 }
 
 #promo-image-left {
@@ -40,8 +41,9 @@
     height: auto;
     border: none;
     position: absolute;
+    top: 50%;
     right: calc(50% + 250px); /* Position it to the left of the centered menu */
-    transform: rotate(30deg);
+    transform: translateY(-50%) rotate(30deg);
 }
 
 #main-menu, #options-menu {

--- a/index.html
+++ b/index.html
@@ -38,13 +38,13 @@
     </div>
     <div id="game-container"></div>
     <div id="start-screen">
+        <img src="assets/images/goliaths.png" id="promo-image-left" alt="Now with Goliaths!">
+        <img src="assets/images/siegetanks.png" id="promo-image-right" alt="Now with Siege Tanks!">
         <div class="start-content-wrapper">
-            <img src="assets/images/goliaths.png" id="promo-image-left" alt="Now with Goliaths!">
             <div id="main-menu">
                 <div id="start-button">Click to Start</div>
                 <div id="options-button">Options</div>
             </div>
-            <img src="assets/images/siegetanks.png" id="promo-image-right" alt="Now with Siege Tanks!">
         </div>
         <div id="options-menu" class="hidden">
             <h2>Options</h2>


### PR DESCRIPTION
## Summary
- keep promo images inside the start screen but outside the layout flow
- position the images at a fixed vertical center so they stay put
- document the change in the changelog

## Testing
- `python3 -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_685859a555b0833287709e34d61b336b