### PR TITLE
Fix SCV2 animation rig

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 - Anchored the main menu promo images so they remain fixed when opening the options menu.
 - Added remote Firebat, Marine and Medic sound effects to the preloader.
 - SCV Mark 2 loads remote animations for idle, walking and repair.
+- SCV Mark 2 animations load correctly using a local rigged model.
 - Assets and sounds now load in parallel for faster startup times.
 - Documented that `apt-utils` and `pygltflib` must be installed at startup.
 

--- a/src/game/preloader.js
+++ b/src/game/preloader.js
@@ -7,16 +7,17 @@ export async function preloadAssets(audioManager) {
     tasks.push(() => assetManager.loadTexture('assets/images/starfield_texture.png', 'skybox'));
     tasks.push(() => assetManager.loadTexture('assets/images/terrain_texture.png', 'ground'));
     tasks.push(() => assetManager.loadGLB('assets/models/scv.glb', 'scv'));
-    tasks.push(() => assetManager.loadGLB('assets/models/scv2.glb', 'scv2'));
+    // Use the rigged idle GLB as the base model for SCV Mark 2
+    tasks.push(() => assetManager.loadGLB('assets/models/animations/SCV/Animation_Idle.glb', 'scv2'));
 
-    // Remote animations for SCV Mark 2
-    const scv2AnimationUrls = {
-        mineRepair: 'https://file.garden/Zy7B0LkdIVpGyzA1/StarCraft/sounds/Terran/Units/SCV/Animation_MineRepair.glb',
-        idle: 'https://file.garden/Zy7B0LkdIVpGyzA1/StarCraft/sounds/Terran/Units/SCV/Animation_Idle.glb',
-        walking: 'https://file.garden/Zy7B0LkdIVpGyzA1/StarCraft/sounds/Terran/Units/SCV/Animation_Walking.glb'
+    // Local animations for SCV Mark 2
+    const scv2AnimationPaths = {
+        mineRepair: 'assets/models/animations/SCV/Animation_MineRepair.glb',
+        idle: 'assets/models/animations/SCV/Animation_Idle.glb',
+        walking: 'assets/models/animations/SCV/Animation_Walking.glb'
     };
-    Object.entries(scv2AnimationUrls).forEach(([key, url]) => {
-        tasks.push(() => assetManager.loadGLB(url, `scv2_${key}`));
+    Object.entries(scv2AnimationPaths).forEach(([key, path]) => {
+        tasks.push(() => assetManager.loadGLB(path, `scv2_${key}`));
     });
     tasks.push(() => assetManager.loadGLB('assets/models/vulture.glb', 'vulture'));
     tasks.push(() => assetManager.loadGLB('assets/models/goliath.glb', 'goliath'));

--- a/src/units/scv-mark-2.js
+++ b/src/units/scv-mark-2.js
@@ -22,6 +22,7 @@ export class SCVMark2 extends SCVBase {
         this.currentAnimation = null;
 
         try {
+            // The rigged SCV2 model is stored with the idle animation clip
             const scvAsset = assetManager.get('scv2');
             this.mesh = this.createMeshFromGLB(scvAsset);
 


### PR DESCRIPTION
## Summary
- load SCV2 model from the rigged idle GLB
- use local GLB clips for SCV2 animations
- document animation fix in the changelog

## Testing
- `python3 -m http.server 8000` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68586bd82a148332a2246d93fa9a9be2