### PR TITLE
Fix SCV2 animation rig

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 - Anchored the main menu promo images so they remain fixed when opening the options menu.
 - Added remote Firebat, Marine and Medic sound effects to the preloader.
 - SCV Mark 2 loads remote animations for idle, walking and repair.
+- SCV Mark 2 now relies on the remote rigged idle model so its animations play correctly.
 - Assets and sounds now load in parallel for faster startup times.
 - Documented that `apt-utils` and `pygltflib` must be installed at startup.
 

--- a/src/game/preloader.js
+++ b/src/game/preloader.js
@@ -7,13 +7,20 @@ export async function preloadAssets(audioManager) {
     tasks.push(() => assetManager.loadTexture('assets/images/starfield_texture.png', 'skybox'));
     tasks.push(() => assetManager.loadTexture('assets/images/terrain_texture.png', 'ground'));
     tasks.push(() => assetManager.loadGLB('assets/models/scv.glb', 'scv'));
-    tasks.push(() => assetManager.loadGLB('assets/models/scv2.glb', 'scv2'));
+    // Load rigged SCV Mark 2 model and animations from remote GLBs
+    tasks.push(() => assetManager.loadGLB(
+        'https://file.garden/Zy7B0LkdIVpGyzA1/StarCraft/sounds/Terran/Units/SCV/Animation_Idle.glb',
+        'scv2'
+    ));
 
     // Remote animations for SCV Mark 2
     const scv2AnimationUrls = {
-        mineRepair: 'https://file.garden/Zy7B0LkdIVpGyzA1/StarCraft/sounds/Terran/Units/SCV/Animation_MineRepair.glb',
-        idle: 'https://file.garden/Zy7B0LkdIVpGyzA1/StarCraft/sounds/Terran/Units/SCV/Animation_Idle.glb',
-        walking: 'https://file.garden/Zy7B0LkdIVpGyzA1/StarCraft/sounds/Terran/Units/SCV/Animation_Walking.glb'
+        mineRepair:
+            'https://file.garden/Zy7B0LkdIVpGyzA1/StarCraft/sounds/Terran/Units/SCV/Animation_MineRepair.glb',
+        idle:
+            'https://file.garden/Zy7B0LkdIVpGyzA1/StarCraft/sounds/Terran/Units/SCV/Animation_Idle.glb',
+        walking:
+            'https://file.garden/Zy7B0LkdIVpGyzA1/StarCraft/sounds/Terran/Units/SCV/Animation_Walking.glb'
     };
     Object.entries(scv2AnimationUrls).forEach(([key, url]) => {
         tasks.push(() => assetManager.loadGLB(url, `scv2_${key}`));

--- a/src/units/scv-mark-2.js
+++ b/src/units/scv-mark-2.js
@@ -22,6 +22,7 @@ export class SCVMark2 extends SCVBase {
         this.currentAnimation = null;
 
         try {
+            // SCV2 uses the rigged idle GLB as its base model
             const scvAsset = assetManager.get('scv2');
             this.mesh = this.createMeshFromGLB(scvAsset);
 


### PR DESCRIPTION
## Summary
- load SCV2 from the remote rigged idle GLB
- fetch SCV2 animations from remote URLs
- document SCV2 animation fix in the changelog

## Testing
- `python3 -m http.server 8000` *(server started and exited without output)*

------
https://chatgpt.com/codex/tasks/task_e_68586bd82a148332a2246d93fa9a9be2