### PR TITLE
Fix SCV2 preload and update changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 - SCV Mark 2 loads remote animations for idle, walking and repair.
 - SCV Mark 2 now relies on the remote rigged idle model so its animations play correctly.
 - SCV Mark 2 animations load correctly using a local rigged model.
+- Removed obsolete remote SCV2 model reference so the unit renders properly.
 - Assets and sounds now load in parallel for faster startup times.
 - Documented that `apt-utils` and `pygltflib` must be installed at startup.
 

--- a/src/game/preloader.js
+++ b/src/game/preloader.js
@@ -7,20 +7,6 @@ export async function preloadAssets(audioManager) {
     tasks.push(() => assetManager.loadTexture('assets/images/starfield_texture.png', 'skybox'));
     tasks.push(() => assetManager.loadTexture('assets/images/terrain_texture.png', 'ground'));
     tasks.push(() => assetManager.loadGLB('assets/models/scv.glb', 'scv'));
-    // Load rigged SCV Mark 2 model and animations from remote GLBs
-    tasks.push(() => assetManager.loadGLB(
-        'https://file.garden/Zy7B0LkdIVpGyzA1/StarCraft/sounds/Terran/Units/SCV/Animation_Idle.glb',
-        'scv2'
-    ));
-
-    // Remote animations for SCV Mark 2
-    const scv2AnimationUrls = {
-        mineRepair:
-            'https://file.garden/Zy7B0LkdIVpGyzA1/StarCraft/sounds/Terran/Units/SCV/Animation_MineRepair.glb',
-        idle:
-            'https://file.garden/Zy7B0LkdIVpGyzA1/StarCraft/sounds/Terran/Units/SCV/Animation_Idle.glb',
-        walking:
-            'https://file.garden/Zy7B0LkdIVpGyzA1/StarCraft/sounds/Terran/Units/SCV/Animation_Walking.glb'
     // Use the rigged idle GLB as the base model for SCV Mark 2
     tasks.push(() => assetManager.loadGLB('assets/models/animations/SCV/Animation_Idle.glb', 'scv2'));
 


### PR DESCRIPTION
## Summary
- remove stray remote SCV2 model entries from the preloader
- note the fix in the changelog

## Testing
- `python3 -m http.server 8000` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_685877cb0d988332b0dd37cdd6c9ada5