### PR TITLE
Fix loading overlay progress bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,5 @@
 - Removed obsolete remote SCV2 model reference so the unit renders properly.
 - Assets and sounds now load in parallel for faster startup times.
 - Documented that `apt-utils` and `pygltflib` must be installed at startup.
+- Loading overlay now shows a progress bar to track asset downloads.
 

--- a/assets/css/overlay.css
+++ b/assets/css/overlay.css
@@ -64,6 +64,11 @@
     text-shadow: 2px 2px 4px #000;
 }
 
+#loading-progress-bar {
+    width: 50%;
+    margin: 10px 0;
+}
+
 #loading-overlay.visible {
     display: flex;
 }

--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
     <div id="global-message-container"></div>
     <div id="loading-overlay">
         <div id="loading-text">Loading...</div>
+        <progress id="loading-progress-bar" max="100" value="0"></progress>
         <div id="credit-text">Built by Lord Tsarcasm</div>
     </div>
     <div id="game-container"></div>

--- a/src/game/preloader.js
+++ b/src/game/preloader.js
@@ -3,6 +3,7 @@ import { assetManager } from '../utils/asset-manager.js';
 export async function preloadAssets(audioManager) {
     const loadingOverlay = document.getElementById('loading-overlay');
     const loadingText = document.getElementById('loading-text');
+    const progressBar = document.getElementById('loading-progress-bar');
     const tasks = [];
     tasks.push(() => assetManager.loadTexture('assets/images/starfield_texture.png', 'skybox'));
     tasks.push(() => assetManager.loadTexture('assets/images/terrain_texture.png', 'ground'));
@@ -206,9 +207,12 @@ export async function preloadAssets(audioManager) {
     let loaded = 0;
 
     const updateProgress = () => {
+        const pct = Math.round((loaded / tasks.length) * 100);
         if (loadingText) {
-            const pct = Math.round((loaded / tasks.length) * 100);
             loadingText.textContent = `Loading... ${pct}%`;
+        }
+        if (progressBar) {
+            progressBar.value = pct;
         }
     };
 


### PR DESCRIPTION
## Summary
- show a progress bar during asset loading
- expose progress bar styling
- update changelog

## Testing
- `python3 -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_685880d804f88332b94b896452906574