### PR TITLE
Fix SCV2 model position

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,5 @@
 - Assets and sounds now load in parallel for faster startup times.
 - Documented that `apt-utils` and `pygltflib` must be installed at startup.
 - Loading overlay now shows a progress bar to track asset downloads.
+- Centered the SCV Mark 2 model so it appears correctly in-game.
 

--- a/src/units/scv-mark-2.js
+++ b/src/units/scv-mark-2.js
@@ -143,7 +143,11 @@ export class SCVMark2 extends SCVBase {
         }
 
         const scaledBox = new THREE.Box3().setFromObject(model);
-        model.position.y = -scaledBox.min.y;
+        model.position.set(
+            -(scaledBox.min.x + scaledBox.max.x) / 2,
+            -scaledBox.min.y,
+            -(scaledBox.min.z + scaledBox.max.z) / 2
+        );
 
         model.traverse((child) => {
             if (child.isMesh) {


### PR DESCRIPTION
## Summary
- fix SCV Mark 2 mesh position when loaded from GLB
- note SCV Mark 2 fix in changelog

## Testing
- `python3 -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_6858854775e48332b06adecc01f6203f