### PR TITLE
Update docs for SCV Mark 2 sound

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ preinstalled before running any project commands.
 - Audio is loaded in `src/utils/audio.js` via the asset manager. Add new sound files to `assets/audio/` and register them in that file.
 - Images live under `assets/images/` and are referenced by HTML or JS modules.
 - Some sound effects are fetched from remote URLs defined in `src/game/preloader.js`.  Arrays such as `scvConstructUrls` and `bgUrls` list the external files.  Each URL is loaded with `assetManager.loadSound` and the resulting sound name is stored on `AudioManager` for playback.  Update these lists in `preloader.js` to change or add remote sounds.
+- The SCV Mark 2's construction sounds are hosted on `file.garden` (e.g. `22_aint_paid_enough.wav`). `preloadAssets` loads them into `audioManager.scvMark2ConstructedSoundNames`, and `spawnUnit` plays one at random when the unit spawns. These URLs are fixed in the code and cannot be manipulated by the client, but they function normally.
 
 ## Testing changes
 There is no automated test suite. After making changes:

--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@
 - Documented that `apt-utils` and `pygltflib` must be installed at startup.
 - Loading overlay now shows a progress bar to track asset downloads.
 - Centered the SCV Mark 2 model so it appears correctly in-game.
-
+- Documented SCV Mark 2 construction sound preloading and that file.garden links are fixed and functional.


### PR DESCRIPTION
## Summary
- document SCV Mark 2 spawn sound details in `AGENTS.md`
- note the sound preload in `README`

## Testing
- `sudo apt-get update -y && sudo apt-get install -y apt-utils`
- `pip install pygltflib`
- `python3 -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_68588d833970833294c7376b76cdfc92