### PR TITLE
Remove apt-utils setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,15 +6,8 @@ This repository contains a small Starcraft-inspired RTS prototype. This monolith
 - Everything under the repository root.
 
 ## Environment
-Always ensure the following packages are installed when the environment
-starts:
-
-```
-apt-get update -y && apt-get install -y apt-utils
-pip install pygltflib
-```
-These tools are required for certain asset workflows and should be
-preinstalled before running any project commands.
+All dependencies are included and no additional packages need to be
+installed manually.
 
 ## Running the project
 1. From the repository root start a local server:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 - SCV Mark 2 animations load correctly using a local rigged model.
 - Removed obsolete remote SCV2 model reference so the unit renders properly.
 - Assets and sounds now load in parallel for faster startup times.
-- Documented that `apt-utils` and `pygltflib` must be installed at startup.
+- Removed requirement to install `apt-utils` and `pygltflib`.
 - Loading overlay now shows a progress bar to track asset downloads.
 - Centered the SCV Mark 2 model so it appears correctly in-game.
 - Documented SCV Mark 2 construction sound preloading and that file.garden links are fixed and functional.


### PR DESCRIPTION
## Summary
- remove apt-utils and pygltflib setup guidance from AGENTS.md
- update changelog to note the removal of that requirement

## Testing
- `python3 -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_68588e995ea48332aa0dcdd64579300a