### PR TITLE
Fix Command Center training icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,4 @@
 - Loading overlay now shows a progress bar to track asset downloads.
 - Centered the SCV Mark 2 model so it appears correctly in-game.
 - Documented SCV Mark 2 construction sound preloading and that file.garden links are fixed and functional.
+- SCV and SCV Mark 2 build commands now show the correct training icons.

--- a/src/buildings/command-center.js
+++ b/src/buildings/command-center.js
@@ -133,10 +133,10 @@ export class CommandCenter {
             const scvsInQueue = this.buildQueue.filter(item => item.type === 'SCV').length;
             const scvCountForCost = Math.max(0, gameState.unitCounts.scv + scvsInQueue - 4);
             const scvCost = Math.round(50 * Math.pow(1.4, scvCountForCost));
-            commandList[0] = { 
-                command: 'train_scv', 
-                hotkey: 'S', 
-                icon: 'assets/images/build_scv2_icon.png', 
+            commandList[0] = {
+                command: 'train_scv',
+                hotkey: 'S',
+                icon: 'assets/images/build_scv_icon.png',
                 name: 'Build SCV',
                 cost: { minerals: scvCost, supply: 1 },
                 buildTime: 17 // seconds
@@ -148,7 +148,7 @@ export class CommandCenter {
             commandList[1] = {
                 command: 'train_scv_mark_2',
                 hotkey: 'D',
-                icon: 'assets/images/build_scv_icon.png',
+                icon: 'assets/images/build_scv2_icon.png',
                 name: 'Build SCV Mark 2',
                 cost: { minerals: scvM2Cost, supply: 1 },
                 buildTime: 22


### PR DESCRIPTION
## Summary
- show correct icons for Command Center SCV commands
- note SCV icon fix in changelog

## Testing
- `python3 -m http.server 8000 &`
- `curl -s http://localhost:8000/index.html | head`

------
https://chatgpt.com/codex/tasks/task_e_685890d25acc833293dd946fc33d8397