### PR TITLE
Add downloader for extra asset manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,4 @@
 - Removed unused SCV Mark 2 model file `assets/models/scv2.glb`.
 - Clarified SCV Mark 2 model comments to no longer imply missing assets.
 - SCV2 idle animation is now loaded from a remote URL.
+- Preloader can now load additional assets from extra-assets.json.

--- a/assets/extra-assets.json
+++ b/assets/extra-assets.json
@@ -1,0 +1,6 @@
+{
+  "glbs": ["assets/models/vulture.glb"],
+  "mp3s": ["assets/audio/select.mp3"],
+  "wavs": ["https://file.garden/Zy7B0LkdIVpGyzA1/StarCraft/sounds/Terran/Units/Firebat/move.wav"],
+  "mp4s": ["https://raw.githubusercontent.com/mediaelement/mediaelement-files/master/big_buck_bunny.mp4"]
+}

--- a/src/game/preloader.js
+++ b/src/game/preloader.js
@@ -1,4 +1,5 @@
 import { assetManager } from '../utils/asset-manager.js';
+import { addExtraPreloadTasks } from './preloader_downloader.js';
 
 export async function preloadAssets(audioManager) {
     const loadingOverlay = document.getElementById('loading-overlay');
@@ -202,6 +203,9 @@ export async function preloadAssets(audioManager) {
     ];
     // This part now uses the AudioManager method
     tasks.push(() => audioManager.loadBackgroundTracks(bgUrls));
+
+    // Load any extra assets defined in assets/extra-assets.json
+    await addExtraPreloadTasks(tasks);
 
     let loaded = 0;
 

--- a/src/game/preloader_downloader.js
+++ b/src/game/preloader_downloader.js
@@ -1,0 +1,28 @@
+import { assetManager } from '../utils/asset-manager.js';
+
+export async function addExtraPreloadTasks(tasks) {
+    try {
+        const response = await fetch('assets/extra-assets.json');
+        if (!response.ok) {
+            console.warn('extra-assets.json not found');
+            return;
+        }
+        const manifest = await response.json();
+
+        const pushTask = (urls, loader, ext) => {
+            if (!Array.isArray(urls)) return;
+            urls.forEach(url => {
+                const base = url.split('/').pop().split('?')[0];
+                const name = `extra_${base.replace('.' + ext, '')}`;
+                tasks.push(() => loader.call(assetManager, url, name));
+            });
+        };
+
+        pushTask(manifest.glbs, assetManager.loadGLB, 'glb');
+        pushTask(manifest.mp3s, assetManager.loadSound, 'mp3');
+        pushTask(manifest.wavs, assetManager.loadSound, 'wav');
+        pushTask(manifest.mp4s, assetManager.loadVideo, 'mp4');
+    } catch (e) {
+        console.warn('Failed to load extra asset manifest', e);
+    }
+}

--- a/src/utils/asset-manager.js
+++ b/src/utils/asset-manager.js
@@ -101,6 +101,26 @@ class AssetManager {
         }
     }
 
+    async loadVideo(url, assetName) {
+        if (this.loadedAssets.has(assetName)) {
+            return this.loadedAssets.get(assetName);
+        }
+        return new Promise((resolve, reject) => {
+            const video = document.createElement('video');
+            video.preload = 'auto';
+            video.src = url;
+            video.onloadeddata = () => {
+                this.loadedAssets.set(assetName, video);
+                console.log(`Loaded Video: ${assetName} from ${url}`);
+                resolve(video);
+            };
+            video.onerror = e => {
+                console.error(`Error loading video asset '${assetName}' from '${url}'.`, e);
+                reject(e);
+            };
+        });
+    }
+
     get(assetName) {
         const asset = this.loadedAssets.get(assetName);
         if (!asset) {


### PR DESCRIPTION
## Summary
- support video preload in `asset-manager`
- load optional assets listed in `assets/extra-assets.json`
- hook downloader into the preloader
- document the new manifest in README

## Testing
- `apt-get update -y`
- `apt-get install -y apt-utils`
- `pip install pygltflib`
- `python3 -m http.server 8000` (terminated immediately)

------
https://chatgpt.com/codex/tasks/task_e_6858c741117c8332b37f195c3717c92e