### PR TITLE
Move changelog button to main menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ This project is a small browser-based real-time strategy game inspired by StarCr
 ## Usage
 - Use the in-game menus to start a match and view the tutorial or changelog.
 - Keyboard and mouse controls mimic classic RTS interactions.
-- The `Changelog / Manual` button in the main menu opens the game manual which is loaded from `0changelog.md`.
+- The `Changelog` button in the main menu opens the game manual which is loaded from `0changelog.md`.
 
 For contribution guidelines and more details see `AGENTS.md`.

--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
             <div id="main-menu">
                 <div id="start-button">Click to Start</div>
                 <div id="options-button">Options</div>
+                <div id="changelog-button">Changelog</div>
             </div>
         </div>
         <div id="options-menu" class="hidden">
@@ -65,7 +66,6 @@
                 <label for="sfx-volume-slider">SFX Volume</label>
                 <input type="range" id="sfx-volume-slider" min="0" max="1" step="0.01" value="1.0">
             </div>
-            <div id="changelog-button">Changelog / Manual</div>
             <div id="back-button">Back</div>
         </div>
     </div>
@@ -185,7 +185,7 @@
     <div id="changelog-modal" class="hidden">
         <div class="changelog-content">
             <button id="close-changelog-modal" class="close-button">&times;</button>
-            <h2>Changelog / Manual</h2>
+            <h2>Changelog</h2>
             <pre id="changelog-output">Loading...</pre>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- show the Changelog button in the main menu
- update the modal header to read "Changelog"
- document the new button name in the README

## Testing
- `python3 -m http.server 8000`
- `curl -I http://localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_6859961aa1a08332bb6f8d845be6e53c