### PR TITLE
Lazy load homepage images

### DIFF
--- a/0changelog.md
+++ b/0changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Images on the main page now use lazy loading to improve initial load time.
 
 ## v0.4.2
 - Plateaus with ramps no longer block pathfinding; `createPlateau` gained an `isObstacle` option.

--- a/index.html
+++ b/index.html
@@ -39,8 +39,8 @@
     </div>
     <div id="game-container"></div>
     <div id="start-screen">
-        <img src="assets/images/goliaths.png" id="promo-image-left" alt="Now with Goliaths!">
-        <img src="assets/images/siegetanks.png" id="promo-image-right" alt="Now with Siege Tanks!">
+        <img src="assets/images/goliaths.png" id="promo-image-left" alt="Now with Goliaths!" loading="lazy">
+        <img src="assets/images/siegetanks.png" id="promo-image-right" alt="Now with Siege Tanks!" loading="lazy">
         <div class="start-content-wrapper">
             <div id="main-menu">
                 <div id="start-button">Click to Start</div>


### PR DESCRIPTION
## Summary
- enable lazy loading for promo images in `index.html`
- document this improvement in the changelog

## Testing
- `apt-get update -y && apt-get install -y apt-utils`
- `python3 -m http.server 8000` *(fails: no browser available)*

------
https://chatgpt.com/codex/tasks/task_e_68599850f7b08332818c5d331b99d8b8