### PR TITLE
Use idle animation from extra assets

### DIFF
--- a/0changelog.md
+++ b/0changelog.md
@@ -4,6 +4,7 @@
 - Images on the main page now use lazy loading to improve initial load time.
 - Command Center uses the GLB model specified in `extra-assets.json` when available.
 - Extra SCV animations for mining, idling and walking are loaded from remote GLB files listed in `extra-assets.json`.
+- SCV Mark 2 idle animation now uses the `Animation_Idle.glb` asset from `extra-assets.json`.
 
 ## v0.4.2
 - Plateaus with ramps no longer block pathfinding; `createPlateau` gained an `isObstacle` option.

--- a/src/units/scv-mark-2.js
+++ b/src/units/scv-mark-2.js
@@ -34,7 +34,8 @@ export class SCVMark2 extends SCVBase {
             this.mixer = new THREE.AnimationMixer(this.mesh);
 
             // Separate animation files are the primary source now
-            const idleAsset = assetManager.get('scv2_idle');
+            // The idle animation comes from the extra-assets manifest
+            const idleAsset = assetManager.get('extra_Animation_Idle');
             const walkAsset = assetManager.get('scv2_walking');
             const mineRepairAsset = assetManager.get('scv2_mineRepair');
 


### PR DESCRIPTION
## Summary
- swap SCV Mark 2 idle animation to use the GLB listed in `extra-assets.json`
- note change in `0changelog.md`

## Testing
- `python3 -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_6859a2fdb6088332901df74edf506c8c