### PR TITLE
Load SCV2 animations from extra-assets manifest

### DIFF
--- a/0changelog.md
+++ b/0changelog.md
@@ -5,6 +5,7 @@
 - Command Center uses the GLB model specified in `extra-assets.json` when available.
 - Extra SCV animations for mining, idling and walking are loaded from remote GLB files listed in `extra-assets.json`.
 - SCV Mark 2 idle animation now uses the `Animation_Idle.glb` asset from `extra-assets.json`.
+- SCV Mark 2 walking and mining animations now also load from `extra-assets.json`.
 
 ## v0.4.2
 - Plateaus with ramps no longer block pathfinding; `createPlateau` gained an `isObstacle` option.

--- a/src/game/preloader.js
+++ b/src/game/preloader.js
@@ -11,15 +11,6 @@ export async function preloadAssets(audioManager) {
     tasks.push(() => assetManager.loadGLB('assets/models/scv.glb', 'scv'));
     tasks.push(() => assetManager.loadGLB('https://file.garden/Zy7B0LkdIVpGyzA1/StarCraft/sounds/Terran/Units/SCV/scv2.glb', 'scv2'));
 
-    // Animations for SCV Mark 2
-    const scv2AnimationPaths = {
-        mineRepair: 'assets/models/animations/SCV/Animation_MineRepair.glb',
-        idle: 'https://file.garden/Zy7B0LkdIVpGyzA1/StarCraft/sounds/Terran/Units/SCV/Animation_Idle.glb',
-        walking: 'https://file.garden/Zy7B0LkdIVpGyzA1/StarCraft/sounds/Terran/Units/SCV/Animation_Walking.glb'
-    };
-    Object.entries(scv2AnimationPaths).forEach(([key, path]) => {
-        tasks.push(() => assetManager.loadGLB(path, `scv2_${key}`));
-    });
     tasks.push(() => assetManager.loadGLB('assets/models/vulture.glb', 'vulture'));
     tasks.push(() => assetManager.loadGLB('assets/models/goliath.glb', 'goliath'));
     tasks.push(() => assetManager.loadGLB('assets/models/wraith.glb', 'wraith'));

--- a/src/units/scv-mark-2.js
+++ b/src/units/scv-mark-2.js
@@ -33,11 +33,10 @@ export class SCVMark2 extends SCVBase {
 
             this.mixer = new THREE.AnimationMixer(this.mesh);
 
-            // Separate animation files are the primary source now
-            // The idle animation comes from the extra-assets manifest
+            // Separate animation files are loaded via the extra-assets manifest
             const idleAsset = assetManager.get('extra_Animation_Idle');
-            const walkAsset = assetManager.get('scv2_walking');
-            const mineRepairAsset = assetManager.get('scv2_mineRepair');
+            const walkAsset = assetManager.get('extra_Animation_Walking');
+            const mineRepairAsset = assetManager.get('extra_Animation_MineRepair');
 
             if (idleAsset.animations && idleAsset.animations[0]) {
                 this.animations.idle = this.mixer.clipAction(idleAsset.animations[0]);


### PR DESCRIPTION
## Summary
- remove hardcoded SCV Mark 2 animation paths from preloader
- load SCV Mark 2 walking & mining animations from `extra-assets.json`
- document new animation loading in the changelog

## Testing
- `python3 -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_6859a45c83988332bd21d01d99caac88