### PR TITLE
Fix SCV facing direction after movement

### DIFF
--- a/0changelog.md
+++ b/0changelog.md
@@ -6,6 +6,7 @@
 - Extra SCV animations for mining, idling and walking are loaded from remote GLB files listed in `extra-assets.json`.
 - SCV Mark 2 idle animation now uses the `Animation_Idle.glb` asset from `extra-assets.json`.
 - SCV Mark 2 walking and mining animations now also load from `extra-assets.json`.
+- SCV units keep their facing direction when idle instead of snapping north.
 
 ## v0.4.2
 - Plateaus with ramps no longer block pathfinding; `createPlateau` gained an `isObstacle` option.

--- a/src/units/scv-mark-2.js
+++ b/src/units/scv-mark-2.js
@@ -29,9 +29,11 @@ export class SCVMark2 extends SCVBase {
 
         try {
             const scvAsset = assetManager.get('scv2');
-            this.mesh = this.createMeshFromGLB(scvAsset);
+            const { wrapper, model } = this.createMeshFromGLB(scvAsset);
+            this.mesh = wrapper;
+            this.model = model;
 
-            this.mixer = new THREE.AnimationMixer(this.mesh);
+            this.mixer = new THREE.AnimationMixer(this.model);
 
             // Separate animation files are loaded via the extra-assets manifest
             const idleAsset = assetManager.get('extra_Animation_Idle');
@@ -161,7 +163,11 @@ export class SCVMark2 extends SCVBase {
         });
         
         this.addCarryVisuals(model);
-        return model;
+
+        const wrapper = new THREE.Group();
+        wrapper.add(model);
+
+        return { wrapper, model };
     }
     
     createProceduralMesh() {

--- a/src/units/scv.js
+++ b/src/units/scv.js
@@ -23,11 +23,13 @@ export class SCV extends SCVBase {
         // Try to use GLB model, otherwise fallback to procedural
         try {
             const scvAsset = assetManager.get('scv');
-            this.mesh = this.createMeshFromGLB(scvAsset);
+            const { wrapper, model } = this.createMeshFromGLB(scvAsset);
+            this.mesh = wrapper;
+            this.model = model;
 
-            // Setup animations
+            // Setup animations on the inner model so rotation isn't overwritten
             if (scvAsset.animations && scvAsset.animations.length) {
-                this.mixer = new THREE.AnimationMixer(this.mesh);
+                this.mixer = new THREE.AnimationMixer(this.model);
                 // Just play the first animation clip found on a loop.
                 const action = this.mixer.clipAction(scvAsset.animations[0]);
                 action.play();
@@ -93,7 +95,11 @@ export class SCV extends SCVBase {
         });
         
         this.addCarryVisuals(model);
-        return model;
+
+        const wrapper = new THREE.Group();
+        wrapper.add(model);
+
+        return { wrapper, model };
     }
 
     createProceduralMesh() {


### PR DESCRIPTION
## Summary
- preserve SCV rotation by adding wrapper group around animated model
- do the same for SCV Mark 2
- note behavior change in changelog

## Testing
- `python3 -m http.server 8000` (server started and stopped without issues)

------
https://chatgpt.com/codex/tasks/task_e_6859a977750c8332a2d89ca2d518dc8a