### PR TITLE
Adjust supply depot lowering offset

### DIFF
--- a/0changelog.md
+++ b/0changelog.md
@@ -8,6 +8,7 @@
 - SCV Mark 2 walking and mining animations now also load from `extra-assets.json`.
 - SCV units keep their facing direction when idle instead of snapping north.
 - Supply Depot uses the GLB model specified in `extra-assets.json` when available.
+- Lowered Supply Depots now sit only one unit below the raised height instead of sinking too deep.
 
 ## v0.4.2
 - Plateaus with ramps no longer block pathfinding; `createPlateau` gained an `isObstacle` option.

--- a/src/buildings/supply-depot.js
+++ b/src/buildings/supply-depot.js
@@ -214,7 +214,11 @@ export class SupplyDepot {
         }
 
         const raisedY = 1.2;
-        const loweredY = -1.0;
+        // When the depot lowers it should only move about one unit down from its
+        // fully raised position. The previous value made it sink much deeper
+        // because the GLB's origin is centered vertically. Moving just a single
+        // unit keeps the top near ground level.
+        const loweredY = raisedY - 1.0;
         const platformTopOffset = 1.1; // Top of the movable part's wall
 
         const updateUnitsOnTop = () => {


### PR DESCRIPTION
## Summary
- reduce supply depot lowering depth so it only goes one unit below its raised height
- document change in changelog

## Testing
- `curl -I http://localhost:8000/index.html`

------
https://chatgpt.com/codex/tasks/task_e_6859ad77688c83328e8999d50ded6ca3