### PR TITLE
Fix SCV2 model path

### DIFF
--- a/0changelog.md
+++ b/0changelog.md
@@ -9,6 +9,7 @@
 - SCV units keep their facing direction when idle instead of snapping north.
 - Supply Depot uses the GLB model specified in `extra-assets.json` when available.
 - Lowered Supply Depots now sit only one unit below the raised height instead of sinking too deep.
+- SCV Mark 2 model now loads from the updated URL in `extra-assets.json`.
 
 ## v0.4.2
 - Plateaus with ramps no longer block pathfinding; `createPlateau` gained an `isObstacle` option.

--- a/src/game/preloader.js
+++ b/src/game/preloader.js
@@ -9,7 +9,13 @@ export async function preloadAssets(audioManager) {
     tasks.push(() => assetManager.loadTexture('assets/images/starfield_texture.png', 'skybox'));
     tasks.push(() => assetManager.loadTexture('assets/images/terrain_texture.png', 'ground'));
     tasks.push(() => assetManager.loadGLB('assets/models/scv.glb', 'scv'));
-    tasks.push(() => assetManager.loadGLB('https://file.garden/Zy7B0LkdIVpGyzA1/StarCraft/sounds/Terran/Units/SCV/scv2.glb', 'scv2'));
+    // SCV Mark 2 model moved under assets/Terran in the extra-assets archive
+    tasks.push(() =>
+        assetManager.loadGLB(
+            'https://file.garden/Zy7B0LkdIVpGyzA1/StarCraft/assets/Terran/scv2.glb',
+            'scv2'
+        )
+    );
 
     tasks.push(() => assetManager.loadGLB('assets/models/vulture.glb', 'vulture'));
     tasks.push(() => assetManager.loadGLB('assets/models/goliath.glb', 'goliath'));


### PR DESCRIPTION
## Summary
- load SCV Mark 2 model from the new location
- document SCV2 model fix

## Testing
- `python3 -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_6859af23a4508332bda92688c64aeb4d