### PR TITLE
Fix building and resource ground offsets

### DIFF
--- a/0changelog.md
+++ b/0changelog.md
@@ -11,6 +11,7 @@
 - Lowered Supply Depots now sit only one unit below the raised height instead of sinking too deep.
 - SCV Mark 2 model now loads from the updated URL in `extra-assets.json`.
 - Minerals, Vespene Geysers, Vultures, Wraiths, Valkyries, Goliaths, Battlecruisers, Science Vessels and Science Facilities now use GLB models from `extra-assets.json` when available.
+- Command Center, Supply Depot, Science Facility and mineral field models now align with the ground instead of appearing half buried.
 
 ## v0.4.2
 - Plateaus with ramps no longer block pathfinding; `createPlateau` gained an `isObstacle` option.

--- a/src/buildings/command-center.js
+++ b/src/buildings/command-center.js
@@ -273,6 +273,13 @@ export class CommandCenter {
             model.scale.set(scale, scale, scale);
         }
 
+        // Shift the model up so its bottom sits on the ground. Some imported
+        // GLB files have their origin at the center which makes them sink half
+        // way below y=0. After scaling we translate the model so the bounding
+        // box minimum is at 0.
+        const adjustedBox = new THREE.Box3().setFromObject(model);
+        model.position.y -= adjustedBox.min.y;
+
         const wrapper = new THREE.Group();
         wrapper.add(model);
 

--- a/src/buildings/science-facility.js
+++ b/src/buildings/science-facility.js
@@ -124,6 +124,11 @@ export class ScienceFacility {
             model.scale.set(scale, scale, scale);
         }
 
+        // Shift the model so its lowest point aligns with the ground. Without
+        // this, models whose pivot is centered appear half buried.
+        const adjustedBox = new THREE.Box3().setFromObject(model);
+        model.position.y -= adjustedBox.min.y;
+
         model.traverse(child => {
             if (child.isMesh) {
                 child.castShadow = true;

--- a/src/buildings/supply-depot.js
+++ b/src/buildings/supply-depot.js
@@ -136,6 +136,12 @@ export class SupplyDepot {
             model.scale.set(scale, scale, scale);
         }
 
+        // Shift model so its base rests on the ground. Imported models may have
+        // an origin at the center causing them to appear half buried. Offset
+        // by the bounding box minimum after scaling.
+        const adjustedBox = new THREE.Box3().setFromObject(model);
+        model.position.y -= adjustedBox.min.y;
+
         const wrapper = new THREE.Group();
         this.movablePart = wrapper; // entire model moves when raising/lowering
         wrapper.add(model);

--- a/src/resources/mineral-field.js
+++ b/src/resources/mineral-field.js
@@ -101,6 +101,11 @@ export class MineralField {
             model.scale.set(scale, scale, scale);
         }
 
+        // Align the model so its bottom touches the ground. Imported models have
+        // their origin at the center, leaving half of them below y=0.
+        const adjustedBox = new THREE.Box3().setFromObject(model);
+        model.position.y -= adjustedBox.min.y;
+
         model.traverse(child => {
             if (child.isMesh) {
                 child.castShadow = true;


### PR DESCRIPTION
## Summary
- fix vertical offset for Command Center, Supply Depot, Science Facility and mineral fields so imported models sit on the ground
- update changelog

## Testing
- `python3 -m http.server 8000`
- `curl -I http://localhost:8000/index.html`

------
https://chatgpt.com/codex/tasks/task_e_6859bcf17e108332968d4361b74a4396