### PR TITLE
Reassign command center build hotkeys

### DIFF
--- a/0changelog.md
+++ b/0changelog.md
@@ -4,6 +4,7 @@
 - Images on the main page now use lazy loading to improve initial load time.
 - Command Center uses the GLB model specified in `extra-assets.json` when available.
 - Extra SCV animations for mining, idling and walking are loaded from remote GLB files listed in `extra-assets.json`.
+- Command Center build hotkeys changed from S/D to F/G to avoid conflicts with WASD.
 - SCV Mark 2 idle animation now uses the `Animation_Idle.glb` asset from `extra-assets.json`.
 - SCV Mark 2 walking and mining animations now also load from `extra-assets.json`.
 - SCV units keep their facing direction when idle instead of snapping north.

--- a/src/buildings/command-center.js
+++ b/src/buildings/command-center.js
@@ -138,7 +138,7 @@ export class CommandCenter {
             const scvCost = Math.round(50 * Math.pow(1.4, scvCountForCost));
             commandList[0] = {
                 command: 'train_scv',
-                hotkey: 'S',
+                hotkey: 'F',
                 icon: 'assets/images/build_scv_icon.png',
                 name: 'Build SCV',
                 cost: { minerals: scvCost, supply: 1 },
@@ -150,7 +150,7 @@ export class CommandCenter {
             const scvM2Cost = Math.round(75 * Math.pow(1.4, scvM2CountForCost));
             commandList[1] = {
                 command: 'train_scv_mark_2',
-                hotkey: 'D',
+                hotkey: 'G',
                 icon: 'assets/images/build_scv2_icon.png',
                 name: 'Build SCV Mark 2',
                 cost: { minerals: scvM2Cost, supply: 1 },


### PR DESCRIPTION
## Summary
- update SCV build commands to use F/G instead of S/D
- note the new hotkeys in the changelog

## Testing
- `python3 -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_6859c22b1a4c8332b229dfecae4d2137