### PR TITLE
Adjust mineral field height

### DIFF
--- a/0changelog.md
+++ b/0changelog.md
@@ -13,6 +13,7 @@
 - SCV Mark 2 model now loads from the updated URL in `extra-assets.json`.
 - Minerals, Vespene Geysers, Vultures, Wraiths, Valkyries, Goliaths, Battlecruisers, Science Vessels and Science Facilities now use GLB models from `extra-assets.json` when available.
 - Command Center, Supply Depot, Science Facility and mineral field models now align with the ground instead of appearing half buried.
+- Mineral field model is lifted slightly to prevent crystals from clipping into the ground.
 
 ## v0.4.2
 - Plateaus with ramps no longer block pathfinding; `createPlateau` gained an `isObstacle` option.

--- a/src/resources/mineral-field.js
+++ b/src/resources/mineral-field.js
@@ -105,6 +105,9 @@ export class MineralField {
         // their origin at the center, leaving half of them below y=0.
         const adjustedBox = new THREE.Box3().setFromObject(model);
         model.position.y -= adjustedBox.min.y;
+        // Some mineral models still appear slightly buried after alignment,
+        // so lift them a bit more to ensure full visibility.
+        model.position.y += 0.1;
 
         model.traverse(child => {
             if (child.isMesh) {


### PR DESCRIPTION
## Summary
- raise mineral field model slightly above the ground
- document mineral field height tweak in changelog

## Testing
- `python3 -m http.server 8000` *(server started and produced no output)*

------
https://chatgpt.com/codex/tasks/task_e_6859c5319f4c833297918327cb0738bb