### PR TITLE
Fix supply depot lowering animation

### DIFF
--- a/0changelog.md
+++ b/0changelog.md
@@ -10,6 +10,7 @@
 - SCV units keep their facing direction when idle instead of snapping north.
 - Supply Depot uses the GLB model specified in `extra-assets.json` when available.
 - Lowered Supply Depots now sit only one unit below the raised height instead of sinking too deep.
+- Fix issue where lowering a Supply Depot reset its position before moving; the depot now sinks smoothly from its raised state.
 - SCV Mark 2 model now loads from the updated URL in `extra-assets.json`.
 - Minerals, Vespene Geysers, Vultures, Wraiths, Valkyries, Goliaths, Battlecruisers, Science Vessels and Science Facilities now use GLB models from `extra-assets.json` when available.
 - Command Center, Supply Depot, Science Facility and mineral field models now align with the ground instead of appearing half buried.

--- a/src/buildings/supply-depot.js
+++ b/src/buildings/supply-depot.js
@@ -142,12 +142,18 @@ export class SupplyDepot {
         const adjustedBox = new THREE.Box3().setFromObject(model);
         model.position.y -= adjustedBox.min.y;
 
-        const wrapper = new THREE.Group();
-        this.movablePart = wrapper; // entire model moves when raising/lowering
-        wrapper.add(model);
-        this.movablePart.position.y = 1.2; // Raised position like procedural version
+        // Root group representing the building's base position in the world.
+        const root = new THREE.Group();
 
-        wrapper.traverse(child => {
+        // Wrapper that actually moves when raising/lowering.
+        const wrapper = new THREE.Group();
+        wrapper.add(model);
+        wrapper.position.y = 1.2; // Raised position like procedural version
+
+        this.movablePart = wrapper;
+        root.add(wrapper);
+
+        root.traverse(child => {
             if (child.isMesh) {
                 child.castShadow = true;
                 child.receiveShadow = true;
@@ -155,7 +161,7 @@ export class SupplyDepot {
             }
         });
 
-        return wrapper;
+        return root;
     }
 
     getCollider() {


### PR DESCRIPTION
## Summary
- fix supply depot lowering transform so it doesn't reset position
- note fix in changelog

## Testing
- `python3 -m http.server 8000` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_6859caaeeaec83328cd6b9d95d7f5620