### PR TITLE
Manual ad activation via '/' key

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 This file contains recent changes. For older entries, see `changelog.old.md`.
 
+[TS] 063025-1656 | [MOD] ui | [ACT] ^UX | [TGT] MessageDisplay.js, ui.js, manual.md | [VAL] Disabled automatic ads and added '/' hotkey to watch promo video. Manual updated. | [REF] src/game/ui/MessageDisplay.js, src/game/ui.js, manual.md
+
 [TS] 063025-1642 | [MOD] ui | [ACT] ^ENH | [TGT] MessageDisplay.js, base.css | [VAL] Ad video now autoplays with loop and shows a close button after 30s instead of auto-closing. Video panel set to relative positioning for button. | [REF] src/game/ui/MessageDisplay.js, assets/css/base.css
 
 [TS] 062925-1542 | [MOD] units | [ACT] ^VAR | [TGT] scv.js, scv-mark-2.js | [VAL] Changed `buildSupplyDepot` hotkey from 'S' to 'U' to resolve WASD conflict. Added @tweakable to hotkey configurations. | [REF] src/units/scv.js, src/units/scv-mark-2.js

--- a/manual.md
+++ b/manual.md
@@ -67,3 +67,5 @@ Your base is the heart of your operation.
 ## 4. Hotkeys
 Many actions have hotkeys for faster execution. Hover your mouse over a command button in the bottom-right panel to see its name, cost, and hotkey. Learning hotkeys is crucial for efficient play.
 
+Press the **/** key at any time to watch the promotional video.
+

--- a/src/game/ui.js
+++ b/src/game/ui.js
@@ -276,6 +276,12 @@ export function initUI(commandExecutor, startGameCallback, audioManager, getGrid
     window.addEventListener('keydown', (e) => {
         if (!menuManager.isGameRunning || menuManager.isPaused) return;
 
+        if (e.key === '/' || e.code === 'Slash') {
+            e.preventDefault();
+            messageDisplay.showVideoAd();
+            return;
+        }
+
         // Find the command associated with the hotkey for the current selection
         const firstSelected = commandCard.currentCommandObject;
         if (firstSelected && firstSelected.commands) {

--- a/src/game/ui/MessageDisplay.js
+++ b/src/game/ui/MessageDisplay.js
@@ -4,7 +4,7 @@ let statusTextPanel, placementTextPanel, globalMessageContainer;
 let audioManagerRef;
 
 /** @tweakable How many status messages must be shown before an "ad" plays. Set to 0 to disable. */
-const adFrequency = 5;
+const adFrequency = 0;
 let statusMessageCount = 0;
 
 /** @tweakable Adjust the video player settings */


### PR DESCRIPTION
## Summary
- ads no longer play automatically
- press `/` to watch the promo video
- note the hotkey in the manual

## Testing
- `npm test` *(fails: no package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6862c0f0d9308332a4fa795525adf85d