### PR TITLE
Fix changelog modal loading

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 This file contains recent changes. For older entries, see `changelog.old.md`.
 
+[TS] 063025-1733 | [MOD] ui | [ACT] ^FIX | [TGT] ModalManager | [VAL] Use relative paths for changelog fetch to restore button | [REF] src/game/ui/ModalManager.js
+
 [TS] 063025-1720 | [MOD] units | [ACT] +CLASS | [TGT] DarkTemplar | [VAL] Added Protoss Dark Templar unit with data file, game integration, selection handling and asset preloading. | [REF] src/protoss/darktemplar.js, assets/data/protoss/darktemplar.json, src/game/preloader.js, src/game/selection.js, src/game/spawn.js, src/game/initial-state.js, assets/asset-list.json
 
 [TS] 063025-1659 | [MOD] docs | [ACT] ^ENH | [TGT] changelog system | [VAL] Split older entries into changelog.old.md and added changelog archive tab. | [REF] changelog.md, changelog.old.md, index.html, assets/css/modals.css, src/game/ui/ModalManager.js

--- a/src/game/ui/ModalManager.js
+++ b/src/game/ui/ModalManager.js
@@ -10,9 +10,10 @@ const closeManualOnClickOutside = true;
 
 /** 
  * @tweakable The filename for the main (recent) changelog document. */
-const CHANGELOG_FILE = 'changelog.md';
+// Use relative paths so the files load correctly regardless of hosting setup
+const CHANGELOG_FILE = './changelog.md';
 /** @tweakable The filename for the old changelog file. */
-const OLD_CHANGELOG_FILE = 'changelog.old.md';
+const OLD_CHANGELOG_FILE = './changelog.old.md';
 /** @tweakable The maximum number of lines to display from the changelog. 0 for no limit. */
 const maxChangelogLines = 50;
 /** @tweakable enable closing the changelog modal by clicking its background */


### PR DESCRIPTION
## Summary
- use relative paths when loading changelog files so the modal works no matter how the game is hosted

## Testing
- `node --check src/game/ui/ModalManager.js`

------
https://chatgpt.com/codex/tasks/task_e_6862c8a1acc48332802720010938fca1