### PR TITLE
Fix README changelog note

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ This project is a small browser-based real-time strategy game inspired by StarCr
 
 ## Usage
 - Use the in-game menus to start a match and view the tutorial or changelog.
-- The `Changelog` button in the main menu opens the game manual which is loaded from `changelog.md`.
+- The `Changelog` button in the main menu opens the changelog modal sourced from `changelog.md` and `changelog.old.md`, not the manual.
 
 For contribution guidelines and more details see `AGENTS.md`.

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 This file contains recent changes. For older entries, see `changelog.old.md`.
 
+[TS] 063025-1748 | [MOD] docs | [ACT] ^FIX | [TGT] README.md | [VAL] Clarified changelog button opens modal sourced from changelog files, not the manual. | [REF] README.md:22
+
 [TS] 063025-1745 | [MOD] ui | [ACT] ^VAR ^FUNC | [TGT] ModalManager | [VAL] Updated changelog paths and reload logic | [REF] src/game/ui/ModalManager.js
 
 [TS] 063025-1733 | [MOD] ui | [ACT] ^FIX | [TGT] ModalManager | [VAL] Use relative paths for changelog fetch to restore button | [REF] src/game/ui/ModalManager.js


### PR DESCRIPTION
## Summary
- clarify that the Changelog button opens a modal sourced from `changelog.md` and `changelog.old.md`
- log the docs change

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6862cd71c4d48332bb03af135fde81fc