### PR TITLE
Fix changelog modal error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 This file contains recent changes. For older entries, see `changelog.old.md`.
 
+
+[TS] 063025-1803 | [MOD] ui | [ACT] ^FIX | [TGT] ModalManager dataset assignment | [VAL] replaced optional chaining with null checks | [REF] src/game/ui/ModalManager.js:80-83
 [TS] 063025-1754 | [MOD] ui | [ACT] -FN -VAR | [TGT] unused modal handlers | [VAL] removed legacy toggle functions and constants | [REF] src/game/ui.js
 [TS] 063025-1748 | [MOD] docs | [ACT] ^FIX | [TGT] README.md | [VAL] Clarified changelog button opens modal sourced from changelog files, not the manual. | [REF] README.md:22
 

--- a/src/game/ui/ModalManager.js
+++ b/src/game/ui/ModalManager.js
@@ -77,8 +77,10 @@ export class ModalManager {
         document.getElementById('assets-tab-button')?.addEventListener('click', () => this.switchManualTab('assets'));
 
         document.getElementById('changelog-button')?.addEventListener('click', () => {
-            document.getElementById('recent-changelog-output')?.dataset.loaded = 'false';
-            document.getElementById('old-changelog-output')?.dataset.loaded = 'false';
+            const recentOut = document.getElementById('recent-changelog-output');
+            if (recentOut) recentOut.dataset.loaded = 'false';
+            const oldOut = document.getElementById('old-changelog-output');
+            if (oldOut) oldOut.dataset.loaded = 'false';
             this.toggleChangelogModal();
         });
         document.getElementById('close-changelog-modal')?.addEventListener('click', () => this.toggleChangelogModal());


### PR DESCRIPTION
## Summary
- avoid optional chaining on assignment for `dataset.loaded`
- document the fix in `changelog.md`

## Testing
- `node --check src/game/ui/ModalManager.js`
- `find src -name '*.js' -print0 | xargs -0 -n1 node --check`

------
https://chatgpt.com/codex/tasks/task_e_6862d0c9ec5c83328075fcb65e61ca12