### PR TITLE
Fix changelog modal path

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,8 @@
 This file contains recent changes. For older entries, see `changelog.old.md`.
 
 
+[TS] 063025-1809 | [MOD] ui | [ACT] ^FIX | [TGT] changelog paths | [VAL] set root-relative changelog file paths | [REF] src/game/ui/ModalManager.js:13-16
+
 [TS] 063025-1803 | [MOD] ui | [ACT] ^FIX | [TGT] ModalManager dataset assignment | [VAL] replaced optional chaining with null checks | [REF] src/game/ui/ModalManager.js:80-83
 [TS] 063025-1754 | [MOD] ui | [ACT] -FN -VAR | [TGT] unused modal handlers | [VAL] removed legacy toggle functions and constants | [REF] src/game/ui.js
 [TS] 063025-1748 | [MOD] docs | [ACT] ^FIX | [TGT] README.md | [VAL] Clarified changelog button opens modal sourced from changelog files, not the manual. | [REF] README.md:22

--- a/src/game/ui/ModalManager.js
+++ b/src/game/ui/ModalManager.js
@@ -10,10 +10,10 @@ const closeManualOnClickOutside = true;
 
 /** 
  * @tweakable The filename for the main (recent) changelog document. */
-// Use relative paths so the files load correctly regardless of hosting setup
-const CHANGELOG_FILE = '../../changelog.md';
+// Use a root-relative path so the files load correctly regardless of host page
+const CHANGELOG_FILE = 'changelog.md';
 /** @tweakable The filename for the old changelog file. */
-const OLD_CHANGELOG_FILE = '../../changelog.old.md';
+const OLD_CHANGELOG_FILE = 'changelog.old.md';
 /** @tweakable The maximum number of lines to display from the changelog. 0 for no limit. */
 const maxChangelogLines = 50;
 /** @tweakable enable closing the changelog modal by clicking its background */


### PR DESCRIPTION
## Summary
- fix the changelog button by using root-relative file paths
- log the fix in `changelog.md`

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6862d2259098833283985179842dc565