### PR TITLE
Add jsdom dependency and update setup docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,13 +35,18 @@ This project is a browser-based real-time strategy (RTS) game built with modern 
 ### Prerequisites
 - A modern web browser (Chrome, Firefox).
 - A local web server.
+- Node.js and npm.
 
 ### Running the Project
-1.  From the repository root, start a local HTTP server. A simple Python server is sufficient:
+1.  Install dependencies:
+    ```bash
+    npm install
+    ```
+2.  From the repository root, start a local HTTP server. A simple Python server is sufficient:
     ```bash
     python3 -m http.server 8000
     ```
-2.  Open your browser and navigate to `http://localhost:8000/`. The `index.html` file is the entry point.
+3.  Open your browser and navigate to `http://localhost:8000/`. The `index.html` file is the entry point.
 
 ## 4. Project Structure
 
@@ -58,7 +63,7 @@ To maintain a clear and automated track of all changes, every contribution must 
     2.  Read `ascl.md` to understand the required logging syntax.
     3.  Add a new entry to the top of `changelog.md` describing your change.
     4.  Commit your code and the updated changelog.
-*   **Automatic Archiving**: `scripts/changelog-archive.js` runs on page load and once per day moves entries older than today from `changelog.md` to `changelog.old.md`.
+*   **Automatic Archiving**: `scripts/changelog-archive.js` runs on page load and once per day moves entries older than today from `changelog.md` to `changelog.old.md`. This script relies on the `jsdom` package listed in `package.json`.
 
 ## 6. How to Add New Units and Buildings
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ This project is a small browser-based real-time strategy game inspired by StarCr
    apt-get update -y && apt-get install -y apt-utils
    ```
 2. Clone this repository and open a shell in the project directory.
+3. Install Node dependencies:
+   ```bash
+   npm install
+   ```
 
 ## Running the Game
 1. Start a local HTTP server from the repository root:

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 This file contains recent changes. For older entries, see the `Archive` tab.
 
+[TS] 063025-1824 | [MOD] deps | [ACT] +FILE | [TGT] package.json | [VAL] added jsdom dependency | [REF] package.json
+[TS] 063025-1824 | [MOD] docs | [ACT] ^DOC | [TGT] README.md, AGENTS.md | [VAL] include npm install instructions and note jsdom | [REF] README.md:6-14, AGENTS.md:33-67
+
 [TS] 063025-1820 | [MOD] docs | [ACT] +FILE ^DOC | [TGT] changelog archive | [VAL] added auto archive script, html loader and AGENTS note | [REF] scripts/changelog-archive.js, index.html:223, AGENTS.md:61
 
 [TS] 063025-1809 | [MOD] ui | [ACT] ^FIX | [TGT] changelog paths | [VAL] set root-relative changelog file paths | [REF] src/game/ui/ModalManager.js:13-16

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "starcraft-rts-prototype",
+  "version": "1.0.0",
+  "description": "Browser-based RTS prototype",
+  "type": "module",
+  "dependencies": {
+    "jsdom": "^22.1.0"
+  }
+}


### PR DESCRIPTION
## Summary
- create `package.json` and add `jsdom` dependency
- document npm installation in README
- update AGENTS guide with Node setup instructions and jsdom note

## Testing
- `npm install --ignore-scripts`

------
https://chatgpt.com/codex/tasks/task_e_6862d5dadc908332bd1104d12499aa8e