### PR TITLE
Fix changelog archiver jsdom import

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ To maintain a clear and automated track of all changes, every contribution must 
     2.  Read `ascl.md` to understand the required logging syntax.
     3.  Add a new entry to the top of `changelog.md` describing your change.
     4.  Commit your code and the updated changelog.
-*   **Automatic Archiving**: `scripts/changelog-archive.js` runs on page load and once per day moves entries older than today from `changelog.md` to `changelog.old.md`. This script relies on the `jsdom` package listed in `package.json`.
+*   **Automatic Archiving**: `scripts/changelog-archive.js` runs on page load and once per day moves entries older than today from `changelog.md` to `changelog.old.md`.
 
 ## 6. How to Add New Units and Buildings
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 This file contains recent changes. For older entries, see the `Archive` tab.
 
+[TS] 063025-1834 | [MOD] archive | [ACT] ^FUNC -MOD ^DOC | [TGT] changelog-archive.js, package.json, AGENTS.md | [VAL] removed jsdom dependency and parse changelog lines directly | [REF] scripts/changelog-archive.js, package.json, AGENTS.md:59-66
+
 [TS] 063025-1824 | [MOD] deps | [ACT] +FILE | [TGT] package.json | [VAL] added jsdom dependency | [REF] package.json
 [TS] 063025-1824 | [MOD] docs | [ACT] ^DOC | [TGT] README.md, AGENTS.md | [VAL] include npm install instructions and note jsdom | [REF] README.md:6-14, AGENTS.md:33-67
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,5 @@
   "version": "1.0.0",
   "description": "Browser-based RTS prototype",
   "type": "module",
-  "dependencies": {
-    "jsdom": "^22.1.0"
-  }
+  "dependencies": {}
 }

--- a/scripts/changelog-archive.js
+++ b/scripts/changelog-archive.js
@@ -1,4 +1,3 @@
-import { JSDOM } from 'https://cdn.jsdelivr.net/npm/jsdom@22.1.0/+esm';
 
 async function archiveChangelog() {
   const lastRun = localStorage.getItem('lastChangelogArchive');
@@ -21,8 +20,7 @@ async function archiveChangelog() {
     const recentText = await recentResp.text();
     const oldText = oldResp.ok ? await oldResp.text() : '';
 
-    const dom = new JSDOM(`<pre>${recentText}</pre>`);
-    const lines = dom.window.document.querySelector('pre').textContent.split('\n');
+    const lines = recentText.split('\n');
 
     const today = new Date();
     today.setHours(0, 0, 0, 0);


### PR DESCRIPTION
## Summary
- drop jsdom from changelog archive script and parse lines directly
- remove jsdom dependency
- update AGENTS doc
- log update

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6862d83d8f4c8332a6e2c697730e1776