### PR TITLE
Fix flight unit orientation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # Changelog
 
+[TS] 063025-1855 | [MOD] units | [ACT] ^FUNC | [TGT] createMeshFromGLB/createProceduralMesh | [VAL] rotated child groups so lookAt controls heading | [REF] src/units/battlecruiser.js:63-120 src/units/dropship.js:87-142 src/units/wraith.js:74-120
 This file contains recent changes. For older entries, see the `Archive` tab.
 
 [TS] 063025-1838 | [MOD] ui | [ACT] +FN ^UX | [TGT] promo modal | [VAL] YouTube iframe triggered by '/' key | [REF] index.html:215-223, assets/css/modals.css:343-366, src/game/ui/ModalManager.js:98-104,253-267, src/game/ui.js:63-67

--- a/src/units/battlecruiser.js
+++ b/src/units/battlecruiser.js
@@ -74,6 +74,7 @@ export class Battlecruiser {
         }
 
         const wrapper = new THREE.Group();
+        model.rotation.y = -Math.PI / 2;
         wrapper.add(model);
 
         wrapper.traverse((child) => {
@@ -82,12 +83,12 @@ export class Battlecruiser {
                 child.userData.owner = this;
             }
         });
-        
-        wrapper.rotation.y = -Math.PI / 2;
+
         return wrapper;
     }
 
     createProceduralMesh() {
+        const wrapper = new THREE.Group();
         const group = new THREE.Group();
         const mainMaterial = new THREE.MeshStandardMaterial({ color: 0x8a9aaa, metalness: 0.8, roughness: 0.4 });
         const darkMaterial = new THREE.MeshStandardMaterial({ color: 0x333333 });
@@ -113,9 +114,10 @@ export class Battlecruiser {
                 child.castShadow = true;
             }
         });
-        
+
         group.rotation.y = -Math.PI / 2;
-        return group;
+        wrapper.add(group);
+        return wrapper;
     }
 
     select() { this.selected = true; this.selectionIndicator.visible = true; }

--- a/src/units/dropship.js
+++ b/src/units/dropship.js
@@ -85,6 +85,7 @@ export class Dropship {
         }
 
         const wrapper = new THREE.Group();
+        model.rotation.y = -Math.PI / 2;
         wrapper.add(model);
 
         wrapper.traverse((child) => {
@@ -98,6 +99,7 @@ export class Dropship {
     }
 
     createProceduralMesh() {
+        const wrapper = new THREE.Group();
         const group = new THREE.Group();
         const mainMaterial = new THREE.MeshStandardMaterial({ color: 0x6a8aaa, metalness: 0.8, roughness: 0.4 });
         const darkMaterial = new THREE.MeshStandardMaterial({ color: 0x333333 });
@@ -135,8 +137,10 @@ export class Dropship {
                 child.castShadow = true;
             }
         });
-        
-        return group;
+
+        group.rotation.y = -Math.PI / 2;
+        wrapper.add(group);
+        return wrapper;
     }
 
     select() { this.selected = true; this.selectionIndicator.visible = true; }

--- a/src/units/wraith.js
+++ b/src/units/wraith.js
@@ -73,6 +73,7 @@ export class Wraith {
         }
 
         const wrapper = new THREE.Group();
+        model.rotation.y = -Math.PI / 2;
         wrapper.add(model);
 
         wrapper.traverse((child) => {
@@ -86,6 +87,7 @@ export class Wraith {
     }
 
     createProceduralMesh() {
+        const wrapper = new THREE.Group();
         const group = new THREE.Group();
         const mainMaterial = new THREE.MeshStandardMaterial({ color: 0x6a8aaa, metalness: 0.8, roughness: 0.4 });
         const cockpitMaterial = new THREE.MeshStandardMaterial({ color: 0x00a1ff, emissive: 0x00a1ff, emissiveIntensity: 0.5 });
@@ -112,9 +114,10 @@ export class Wraith {
                 child.castShadow = true;
             }
         });
-        
+
         group.rotation.y = -Math.PI / 2;
-        return group;
+        wrapper.add(group);
+        return wrapper;
     }
 
     select() { this.selected = true; this.selectionIndicator.visible = true; }


### PR DESCRIPTION
## Summary
- rotate child groups instead of root for wraith, dropship and battlecruiser
- document update

## Testing
- `node scripts/changelog-archive.js` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6862dc76b0208332a275c950664ea9f9