### PR TITLE
Update docs for archiving and unit workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project is a small browser-based real-time strategy game inspired by StarCr
    apt-get update -y && apt-get install -y apt-utils
    ```
 2. Clone this repository and open a shell in the project directory.
-3. Install Node dependencies:
+3. Install Node dependencies (includes `jsdom` for the changelog archiving script):
    ```bash
    npm install
    ```
@@ -24,5 +24,10 @@ This project is a small browser-based real-time strategy game inspired by StarCr
 ## Usage
 - Use the in-game menus to start a match and view the tutorial or changelog.
 - The `Changelog` button in the main menu opens the changelog modal sourced from `changelog.md` and `changelog.old.md`, not the manual.
+
+## Development Notes
+- `scripts/changelog-archive.js` automatically runs when `index.html` loads and moves entries older than today from `changelog.md` to `changelog.old.md`.
+- Ensure you run `npm install` to fetch `jsdom`, which the archiving script depends on.
+- To add a new unit, create a stats JSON file and corresponding unit class as outlined in `agent-units.md`. Log your work in `changelog.md`; the archiver will relocate older logs on the next page load.
 
 For contribution guidelines and more details see `AGENTS.md`.

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Changelog
+[TS] 063025-1904 | [MOD] docs | [ACT] ^DOC | [TGT] README.md | [VAL] note changelog archiving script, jsdom install, and unit add instructions | [REF] README.md:11-31
 [TS] 063025-1859 | [MOD] spawn | [ACT] ^FUNC ^VAR | [TGT] spawnUnit, devUnitSpawnLayout.startPosition | [VAL] ensure walkable spawn coords and move dev units onto land | [REF] src/game/spawn.js:127-134 src/game/initial-state.js:28-33
 
 [TS] 063025-1855 | [MOD] units | [ACT] ^FUNC | [TGT] createMeshFromGLB/createProceduralMesh | [VAL] rotated child groups so lookAt controls heading | [REF] src/units/battlecruiser.js:63-120 src/units/dropship.js:87-142 src/units/wraith.js:74-120


### PR DESCRIPTION
## Summary
- clarify that `npm install` fetches jsdom
- document mandatory changelog archiving and unit workflow

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_6862df286e2c83329771911ff1a7132f