### PR TITLE
Fix Terran ship orientation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 This file contains recent changes. For older entries, see the `Archive` tab.
 
+[TS] 063025-2135 | [MOD] units | [ACT] ^FIX | [TGT] battlecruiser,wraith,dropship orientation | [VAL] rotated models 180deg to face forward | [REF] src/units/battlecruiser.js:77,118 src/units/wraith.js:76,118 src/units/dropship.js:88,141
+
 [TS] 063025-1903 | [MOD] docs | [ACT] ^DOC | [TGT] README.md | [VAL] note '/' key opens promo video | [REF] README.md:25-27
 [TS] 063025-1859 | [MOD] spawn | [ACT] ^FUNC ^VAR | [TGT] spawnUnit, devUnitSpawnLayout.startPosition | [VAL] ensure walkable spawn coords and move dev units onto land | [REF] src/game/spawn.js:127-134 src/game/initial-state.js:28-33
 [TS] 063025-1904 | [MOD] docs | [ACT] ^DOC | [TGT] agent-units.md | [VAL] replaced missing unit integration sections, referenced High Templar example | [REF] agent-units.md:1-51

--- a/src/units/battlecruiser.js
+++ b/src/units/battlecruiser.js
@@ -74,7 +74,7 @@ export class Battlecruiser {
         }
 
         const wrapper = new THREE.Group();
-        model.rotation.y = -Math.PI / 2;
+        model.rotation.y = Math.PI / 2; // Rotate 180° so forward matches lookAt
         wrapper.add(model);
 
         wrapper.traverse((child) => {
@@ -115,7 +115,7 @@ export class Battlecruiser {
             }
         });
 
-        group.rotation.y = -Math.PI / 2;
+        group.rotation.y = Math.PI / 2; // Rotate 180° so forward matches lookAt
         wrapper.add(group);
         return wrapper;
     }

--- a/src/units/dropship.js
+++ b/src/units/dropship.js
@@ -85,7 +85,7 @@ export class Dropship {
         }
 
         const wrapper = new THREE.Group();
-        model.rotation.y = -Math.PI / 2;
+        model.rotation.y = Math.PI / 2; // Rotate 180° so forward matches lookAt
         wrapper.add(model);
 
         wrapper.traverse((child) => {
@@ -138,7 +138,7 @@ export class Dropship {
             }
         });
 
-        group.rotation.y = -Math.PI / 2;
+        group.rotation.y = Math.PI / 2; // Rotate 180° so forward matches lookAt
         wrapper.add(group);
         return wrapper;
     }

--- a/src/units/wraith.js
+++ b/src/units/wraith.js
@@ -73,7 +73,7 @@ export class Wraith {
         }
 
         const wrapper = new THREE.Group();
-        model.rotation.y = -Math.PI / 2;
+        model.rotation.y = Math.PI / 2; // Rotate 180° so forward matches lookAt
         wrapper.add(model);
 
         wrapper.traverse((child) => {
@@ -115,7 +115,7 @@ export class Wraith {
             }
         });
 
-        group.rotation.y = -Math.PI / 2;
+        group.rotation.y = Math.PI / 2; // Rotate 180° so forward matches lookAt
         wrapper.add(group);
         return wrapper;
     }


### PR DESCRIPTION
## Summary
- rotate battlecruiser, wraith and dropship models 180 degrees
- log the unit orientation fix

## Testing
- `node --check src/units/battlecruiser.js`
- `node --check src/units/wraith.js`
- `node --check src/units/dropship.js`
- `node scripts/changelog-archive.js` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_686302b4f9dc8332b8249c29728bcb4c