### PR TITLE
Add basic Zerg race

### DIFF
--- a/assets/asset-list.json
+++ b/assets/asset-list.json
@@ -111,5 +111,17 @@
   "/assets/images/vulture_portrait.png",
   "/assets/images/wraith_portrait.png",
   "/assets/images/ws-sc-bg.png",
-  "/assets/images/yamato_cannon_icon.png"
+  "/assets/images/yamato_cannon_icon.png",
+  "/assets/models/zerg/zergling.glb",
+  "/assets/models/zerg/hydralisk.glb",
+  "/assets/models/zerg/hatchery.glb",
+  "/assets/images/zerg/zergling_portrait.png",
+  "/assets/images/zerg/hydralisk_portrait.png",
+  "/assets/images/zerg/hatchery_portrait.png",
+  "/assets/images/zerg/larva_portrait.png",
+  "/assets/images/zerg/train_zergling_icon.png",
+  "/assets/images/zerg/train_hydralisk_icon.png",
+  "/assets/images/zerg/build_hatchery_icon.png",
+  "/assets/images/zerg/metabolic_boost_icon.png",
+  "/assets/images/zerg/muscular_augments_icon.png"
 ]

--- a/assets/data/zerg/hydralisk.json
+++ b/assets/data/zerg/hydralisk.json
@@ -1,0 +1,7 @@
+{
+    "stats": {
+        "health": 80,
+        "armor": 0,
+        "speed": 3.5
+    }
+}

--- a/assets/data/zerg/zergling.json
+++ b/assets/data/zerg/zergling.json
@@ -1,0 +1,7 @@
+{
+    "stats": {
+        "health": 35,
+        "armor": 0,
+        "speed": 4.5
+    }
+}

--- a/changelog.md
+++ b/changelog.md
@@ -1,36 +1,7 @@
 # Changelog
 
+
 This file contains recent changes. For older entries, see the `Archive` tab.
-[TS] 063025-2153 | [MOD] resources | [ACT] ^FIX | [TGT] MineralField model offset | [VAL] wrapper group preserves vertical offset | [REF] src/resources/mineral-field.js:17-24,112-120
+[TS] 071025-2206 | [MOD] zerg | [ACT] +CLASS +FILE ^FUNC | [TGT] Zerg race integration | [VAL] added Zerg units, Hatchery, creep and larva mechanics, archived changelog | [REF] src/zerg/* src/utils/terrain.js src/game/spawn.js changelog.old.md
 
-[TS] 063025-2143 | [MOD] units | [ACT] ^FIX | [TGT] science_vessel orientation | [VAL] rotated model 180deg to face forward | [REF] src/units/science-vessel.js:86,124
 
-[TS] 063025-2139 | [MOD] docs | [ACT] ^ENH | [TGT] agent-units.md | [VAL] expanded unit guide with detailed steps | [REF] agent-units.md:1-81
-[TS] 063025-2135 | [MOD] units | [ACT] ^FIX | [TGT] battlecruiser,wraith,dropship orientation | [VAL] rotated models 180deg to face forward | [REF] src/units/battlecruiser.js:77,118 src/units/wraith.js:76,118 src/units/dropship.js:88,141
-
-[TS] 063025-1903 | [MOD] docs | [ACT] ^DOC | [TGT] README.md | [VAL] note '/' key opens promo video | [REF] README.md:25-27
-[TS] 063025-1859 | [MOD] spawn | [ACT] ^FUNC ^VAR | [TGT] spawnUnit, devUnitSpawnLayout.startPosition | [VAL] ensure walkable spawn coords and move dev units onto land | [REF] src/game/spawn.js:127-134 src/game/initial-state.js:28-33
-[TS] 063025-1904 | [MOD] docs | [ACT] ^DOC | [TGT] agent-units.md | [VAL] replaced missing unit integration sections, referenced High Templar example | [REF] agent-units.md:1-51
-[TS] 063025-1859 | [MOD] spawn | [ACT] ^FUNC ^VAR | [TGT] spawnUnit, devUnitSpawnLayout.startPosition | [VAL] ensure walkable spawn coords and move dev units onto land | [REF] src/game/spawn.js:127-134 src/game/initial-state.js:28-33
-[TS] 063025-1855 | [MOD] units | [ACT] ^FUNC | [TGT] createMeshFromGLB/createProceduralMesh | [VAL] rotated child groups so lookAt controls heading | [REF] src/units/battlecruiser.js:63-120 src/units/dropship.js:87-142 src/units/wraith.js:74-120
-[TS] 063025-1904 | [MOD] docs | [ACT] ^DOC | [TGT] README.md | [VAL] note changelog archiving script, jsdom install, and unit add instructions | [REF] README.md:11-31
-[TS] 063025-1908 | [MOD] units | [ACT] +CLASS +FILE | [TGT] HighTemplar | [VAL] Added Protoss High Templar unit with data and game integration. | [REF] src/protoss/hightemplar.js, assets/data/protoss/hightemplar.json, src/game/spawn.js, src/game/preloader.js, src/game/initial-state.js, src/game/selection.js
-[TS] 063025-1905 | [MOD] ui | [ACT] MIGR +CLASS -FN | [TGT] ModalManager split | [VAL] extracted ManualModal, ChangelogModal, DevLogModal and PromoModal classes | [REF] src/game/ui/modals
-[TS] 063025-1859 | [MOD] spawn | [ACT] ^FUNC ^VAR | [TGT] spawnUnit, devUnitSpawnLayout.startPosition | [VAL] ensure walkable spawn coords and move dev units onto land | [REF] src/game/spawn.js:127-134 src/game/initial-state.js:28-33
-[TS] 063025-1855 | [MOD] units | [ACT] ^FUNC | [TGT] createMeshFromGLB/createProceduralMesh | [VAL] rotated child groups so lookAt controls heading | [REF] src/units/battlecruiser.js:63-120 src/units/dropship.js:87-142 src/units/wraith.js:74-120
-[TS] 063025-1838 | [MOD] ui | [ACT] +FN ^UX | [TGT] promo modal | [VAL] YouTube iframe triggered by '/' key | [REF] index.html:215-223, assets/css/modals.css:343-366, src/game/ui/ModalManager.js:98-104,253-267, src/game/ui.js:63-67
-[TS] 063025-1834 | [MOD] archive | [ACT] ^FUNC -MOD ^DOC | [TGT] changelog-archive.js, package.json, AGENTS.md | [VAL] removed jsdom dependency and parse changelog lines directly | [REF] scripts/changelog-archive.js, package.json, AGENTS.md:59-66
-[TS] 063025-1824 | [MOD] deps | [ACT] +FILE | [TGT] package.json | [VAL] added jsdom dependency | [REF] package.json
-[TS] 063025-1824 | [MOD] docs | [ACT] ^DOC | [TGT] README.md, AGENTS.md | [VAL] include npm install instructions and note jsdom | [REF] README.md:6-14, AGENTS.md:33-67
-[TS] 063025-1820 | [MOD] docs | [ACT] +FILE ^DOC | [TGT] changelog archive | [VAL] added auto archive script, html loader and AGENTS note | [REF] scripts/changelog-archive.js, index.html:223, AGENTS.md:61
-[TS] 063025-1809 | [MOD] ui | [ACT] ^FIX | [TGT] changelog paths | [VAL] set root-relative changelog file paths | [REF] src/game/ui/ModalManager.js:13-16
-[TS] 063025-1803 | [MOD] ui | [ACT] ^FIX | [TGT] ModalManager dataset assignment | [VAL] replaced optional chaining with null checks | [REF] src/game/ui/ModalManager.js:80-83
-[TS] 063025-1754 | [MOD] ui | [ACT] -FN -VAR | [TGT] unused modal handlers | [VAL] removed legacy toggle functions and constants | [REF] src/game/ui.js
-[TS] 063025-1748 | [MOD] docs | [ACT] ^FIX | [TGT] README.md | [VAL] Clarified changelog button opens modal sourced from changelog files, not the manual. | [REF] README.md:22
-[TS] 063025-1745 | [MOD] ui | [ACT] ^VAR ^FUNC | [TGT] ModalManager | [VAL] Updated changelog paths and reload logic | [REF] src/game/ui/ModalManager.js
-[TS] 063025-1733 | [MOD] ui | [ACT] ^FIX | [TGT] ModalManager | [VAL] Use relative paths for changelog fetch to restore button | [REF] src/game/ui/ModalManager.js
-[TS] 063025-1720 | [MOD] units | [ACT] +CLASS | [TGT] DarkTemplar | [VAL] Added Protoss Dark Templar unit with data file, game integration, selection handling and asset preloading. | [REF] src/protoss/darktemplar.js, assets/data/protoss/darktemplar.json, src/game/preloader.js, src/game/selection.js, src/game/spawn.js, src/game/initial-state.js, assets/asset-list.json
-[TS] 063025-1659 | [MOD] docs | [ACT] ^ENH | [TGT] changelog system | [VAL] Split older entries into changelog.old.md and added changelog archive tab. | [REF] changelog.md, changelog.old.md, index.html, assets/css/modals.css, src/game/ui/ModalManager.js
-[TS] 063025-1049 | [MOD] ui | [ACT] ^ENH | [TGT] MessageDisplay.js, base.css | [VAL] Ad video now autoplays with loop and shows a close button after 30s instead of auto-closing. Video panel set to relative positioning for button. | [REF] src/game/ui/MessageDisplay.js, assets/css/base.css
-[TS] 063025-1656 | [MOD] ui | [ACT] ^UX | [TGT] MessageDisplay.js, ui.js, manual.md | [VAL] Disabled automatic ads and added '/' hotkey to watch promo video. Manual updated. | [REF] src/game/ui/MessageDisplay.js, src/game/ui.js, manual.md
-[TS] 063025-1642 | [MOD] ui | [ACT] ^ENH | [TGT] MessageDisplay.js, base.css | [VAL] Ad video now autoplays with loop and shows a close button after 30s instead of auto-closing. Video panel set to relative positioning for button. | [REF] src/game/ui/MessageDisplay.js, assets/css/base.css

--- a/changelog.old.md
+++ b/changelog.old.md
@@ -1,4 +1,37 @@
 # Archived Changelog
+[TS] 063025-2153 | [MOD] resources | [ACT] ^FIX | [TGT] MineralField model offset | [VAL] wrapper group preserves vertical offset | [REF] src/resources/mineral-field.js:17-24,112-120
+
+[TS] 063025-2143 | [MOD] units | [ACT] ^FIX | [TGT] science_vessel orientation | [VAL] rotated model 180deg to face forward | [REF] src/units/science-vessel.js:86,124
+
+[TS] 063025-2139 | [MOD] docs | [ACT] ^ENH | [TGT] agent-units.md | [VAL] expanded unit guide with detailed steps | [REF] agent-units.md:1-81
+[TS] 063025-2135 | [MOD] units | [ACT] ^FIX | [TGT] battlecruiser,wraith,dropship orientation | [VAL] rotated models 180deg to face forward | [REF] src/units/battlecruiser.js:77,118 src/units/wraith.js:76,118 src/units/dropship.js:88,141
+
+[TS] 063025-1903 | [MOD] docs | [ACT] ^DOC | [TGT] README.md | [VAL] note '/' key opens promo video | [REF] README.md:25-27
+[TS] 063025-1859 | [MOD] spawn | [ACT] ^FUNC ^VAR | [TGT] spawnUnit, devUnitSpawnLayout.startPosition | [VAL] ensure walkable spawn coords and move dev units onto land | [REF] src/game/spawn.js:127-134 src/game/initial-state.js:28-33
+[TS] 063025-1904 | [MOD] docs | [ACT] ^DOC | [TGT] agent-units.md | [VAL] replaced missing unit integration sections, referenced High Templar example | [REF] agent-units.md:1-51
+[TS] 063025-1859 | [MOD] spawn | [ACT] ^FUNC ^VAR | [TGT] spawnUnit, devUnitSpawnLayout.startPosition | [VAL] ensure walkable spawn coords and move dev units onto land | [REF] src/game/spawn.js:127-134 src/game/initial-state.js:28-33
+[TS] 063025-1855 | [MOD] units | [ACT] ^FUNC | [TGT] createMeshFromGLB/createProceduralMesh | [VAL] rotated child groups so lookAt controls heading | [REF] src/units/battlecruiser.js:63-120 src/units/dropship.js:87-142 src/units/wraith.js:74-120
+[TS] 063025-1904 | [MOD] docs | [ACT] ^DOC | [TGT] README.md | [VAL] note changelog archiving script, jsdom install, and unit add instructions | [REF] README.md:11-31
+[TS] 063025-1908 | [MOD] units | [ACT] +CLASS +FILE | [TGT] HighTemplar | [VAL] Added Protoss High Templar unit with data and game integration. | [REF] src/protoss/hightemplar.js, assets/data/protoss/hightemplar.json, src/game/spawn.js, src/game/preloader.js, src/game/initial-state.js, src/game/selection.js
+[TS] 063025-1905 | [MOD] ui | [ACT] MIGR +CLASS -FN | [TGT] ModalManager split | [VAL] extracted ManualModal, ChangelogModal, DevLogModal and PromoModal classes | [REF] src/game/ui/modals
+[TS] 063025-1859 | [MOD] spawn | [ACT] ^FUNC ^VAR | [TGT] spawnUnit, devUnitSpawnLayout.startPosition | [VAL] ensure walkable spawn coords and move dev units onto land | [REF] src/game/spawn.js:127-134 src/game/initial-state.js:28-33
+[TS] 063025-1855 | [MOD] units | [ACT] ^FUNC | [TGT] createMeshFromGLB/createProceduralMesh | [VAL] rotated child groups so lookAt controls heading | [REF] src/units/battlecruiser.js:63-120 src/units/dropship.js:87-142 src/units/wraith.js:74-120
+[TS] 063025-1838 | [MOD] ui | [ACT] +FN ^UX | [TGT] promo modal | [VAL] YouTube iframe triggered by '/' key | [REF] index.html:215-223, assets/css/modals.css:343-366, src/game/ui/ModalManager.js:98-104,253-267, src/game/ui.js:63-67
+[TS] 063025-1834 | [MOD] archive | [ACT] ^FUNC -MOD ^DOC | [TGT] changelog-archive.js, package.json, AGENTS.md | [VAL] removed jsdom dependency and parse changelog lines directly | [REF] scripts/changelog-archive.js, package.json, AGENTS.md:59-66
+[TS] 063025-1824 | [MOD] deps | [ACT] +FILE | [TGT] package.json | [VAL] added jsdom dependency | [REF] package.json
+[TS] 063025-1824 | [MOD] docs | [ACT] ^DOC | [TGT] README.md, AGENTS.md | [VAL] include npm install instructions and note jsdom | [REF] README.md:6-14, AGENTS.md:33-67
+[TS] 063025-1820 | [MOD] docs | [ACT] +FILE ^DOC | [TGT] changelog archive | [VAL] added auto archive script, html loader and AGENTS note | [REF] scripts/changelog-archive.js, index.html:223, AGENTS.md:61
+[TS] 063025-1809 | [MOD] ui | [ACT] ^FIX | [TGT] changelog paths | [VAL] set root-relative changelog file paths | [REF] src/game/ui/ModalManager.js:13-16
+[TS] 063025-1803 | [MOD] ui | [ACT] ^FIX | [TGT] ModalManager dataset assignment | [VAL] replaced optional chaining with null checks | [REF] src/game/ui/ModalManager.js:80-83
+[TS] 063025-1754 | [MOD] ui | [ACT] -FN -VAR | [TGT] unused modal handlers | [VAL] removed legacy toggle functions and constants | [REF] src/game/ui.js
+[TS] 063025-1748 | [MOD] docs | [ACT] ^FIX | [TGT] README.md | [VAL] Clarified changelog button opens modal sourced from changelog files, not the manual. | [REF] README.md:22
+[TS] 063025-1745 | [MOD] ui | [ACT] ^VAR ^FUNC | [TGT] ModalManager | [VAL] Updated changelog paths and reload logic | [REF] src/game/ui/ModalManager.js
+[TS] 063025-1733 | [MOD] ui | [ACT] ^FIX | [TGT] ModalManager | [VAL] Use relative paths for changelog fetch to restore button | [REF] src/game/ui/ModalManager.js
+[TS] 063025-1720 | [MOD] units | [ACT] +CLASS | [TGT] DarkTemplar | [VAL] Added Protoss Dark Templar unit with data file, game integration, selection handling and asset preloading. | [REF] src/protoss/darktemplar.js, assets/data/protoss/darktemplar.json, src/game/preloader.js, src/game/selection.js, src/game/spawn.js, src/game/initial-state.js, assets/asset-list.json
+[TS] 063025-1659 | [MOD] docs | [ACT] ^ENH | [TGT] changelog system | [VAL] Split older entries into changelog.old.md and added changelog archive tab. | [REF] changelog.md, changelog.old.md, index.html, assets/css/modals.css, src/game/ui/ModalManager.js
+[TS] 063025-1049 | [MOD] ui | [ACT] ^ENH | [TGT] MessageDisplay.js, base.css | [VAL] Ad video now autoplays with loop and shows a close button after 30s instead of auto-closing. Video panel set to relative positioning for button. | [REF] src/game/ui/MessageDisplay.js, assets/css/base.css
+[TS] 063025-1656 | [MOD] ui | [ACT] ^UX | [TGT] MessageDisplay.js, ui.js, manual.md | [VAL] Disabled automatic ads and added '/' hotkey to watch promo video. Manual updated. | [REF] src/game/ui/MessageDisplay.js, src/game/ui.js, manual.md
+[TS] 063025-1642 | [MOD] ui | [ACT] ^ENH | [TGT] MessageDisplay.js, base.css | [VAL] Ad video now autoplays with loop and shows a close button after 30s instead of auto-closing. Video panel set to relative positioning for button. | [REF] src/game/ui/MessageDisplay.js, assets/css/base.css
 
 [TS] 062925-1542 | [MOD] units | [ACT] ^VAR | [TGT] scv.js, scv-mark-2.js | [VAL] Changed `buildSupplyDepot` hotkey from 'S' to 'U' to resolve WASD conflict. Added @tweakable to hotkey configurations. | [REF] src/units/scv.js, src/units/scv-mark-2.js
 [TS] 062925-1541 | [MOD] units | [ACT] ^FIX | [TGT] scv.js, scv-mark-2.js | [VAL] Remapped SCV and SCV Mark 2 hotkeys to resolve conflicts with WASD camera controls. Centralized keybinds into tweakable objects. | [REF] src/units/scv.js, src/units/scv-mark-2.js

--- a/needed.json
+++ b/needed.json
@@ -1,0 +1,50 @@
+[
+  {
+    "path": "assets/models/zerg/zergling.glb",
+    "description": "Low-poly Zergling creature from StarCraft with sharp claws, hunched posture, organic carapace, no background"
+  },
+  {
+    "path": "assets/models/zerg/hydralisk.glb",
+    "description": "Low-poly Hydralisk with tall serpentine body and spiny crest, no background"
+  },
+  {
+    "path": "assets/models/zerg/hatchery.glb",
+    "description": "Model of a Zerg Hatchery structure with organic, fleshy appearance, no background"
+  },
+  {
+    "path": "assets/images/zerg/zergling_portrait.png",
+    "description": "Portrait of a Zergling head, facing slightly left, transparent background"
+  },
+  {
+    "path": "assets/images/zerg/hydralisk_portrait.png",
+    "description": "Portrait of Hydralisk snarling, transparent background"
+  },
+  {
+    "path": "assets/images/zerg/hatchery_portrait.png",
+    "description": "Icon-style portrait of a Zerg Hatchery, transparent background"
+  },
+  {
+    "path": "assets/images/zerg/larva_portrait.png",
+    "description": "Small larva creature portrait, transparent background"
+  },
+  {
+    "path": "assets/images/zerg/train_zergling_icon.png",
+    "description": "Command card icon showing a Zergling ready to hatch"
+  },
+  {
+    "path": "assets/images/zerg/train_hydralisk_icon.png",
+    "description": "Command card icon for training a Hydralisk"
+  },
+  {
+    "path": "assets/images/zerg/build_hatchery_icon.png",
+    "description": "Command card icon to build a Zerg Hatchery"
+  },
+  {
+    "path": "assets/images/zerg/metabolic_boost_icon.png",
+    "description": "Upgrade icon depicting Zergling speed evolution"
+  },
+  {
+    "path": "assets/images/zerg/muscular_augments_icon.png",
+    "description": "Upgrade icon representing Hydralisk range evolution"
+  }
+]

--- a/src/game/gameState.js
+++ b/src/game/gameState.js
@@ -23,6 +23,8 @@ export const gameState = {
         dropThrusters: false,
         yamatoGun: false,
         behemothReactor: false,
+        metabolicBoost: false,
+        muscularAugments: false,
     },
     academyBuilt: false,
     engineeringBayBuilt: false,
@@ -36,6 +38,7 @@ export const gameState = {
     covertOpsBuilt: false,
     comsatStationBuilt: false,
     nuclearSiloBuilt: false,
+    hatcheryBuilt: false,
     onFactoryBuilt: null,
     mapChunksUnlocked: 1,
 };

--- a/src/game/initial-state.js
+++ b/src/game/initial-state.js
@@ -24,6 +24,8 @@ import { Adept } from '../protoss/adept.js';
 import { Dragoon } from '../protoss/dragoon.js';
 import { DarkTemplar } from '../protoss/darktemplar.js';
 import { HighTemplar } from '../protoss/hightemplar.js';
+import { Zergling } from '../zerg/zergling.js';
+import { Hydralisk } from '../zerg/hydralisk.js';
 
 /** @tweakable The layout for spawning all dev units on the map. */
 const devUnitSpawnLayout = {
@@ -170,6 +172,13 @@ export function setupInitialState({
         gameState.vespene += 500;
         
         pathfinder.updateObstacles(collidableObjects);
+
+        const hatchery = spawnBuilding('build_hatchery', new THREE.Vector3(-5, 0, -15), { isUnderConstruction: false });
+        hatchery.onConstructionComplete(gameState);
+        const z1 = new Zergling(new THREE.Vector3(-5, 0, -20));
+        const h1 = new Hydralisk(new THREE.Vector3(-8, 0, -20));
+        scene.add(z1.mesh); units.push(z1); selectables.push(z1);
+        scene.add(h1.mesh); units.push(h1); selectables.push(h1);
     }
     
     pathfinder.updateObstacles(collidableObjects);

--- a/src/game/preloader.js
+++ b/src/game/preloader.js
@@ -27,6 +27,9 @@ export async function preloadAssets(audioManager) {
     tasks.push(() => assetManager.loadGLB('assets/models/protoss/dragoon.glb', 'protoss_dragoon'));
     tasks.push(() => assetManager.loadGLB('assets/models/protoss/darktemplar.glb', 'protoss_darktemplar'));
     tasks.push(() => assetManager.loadGLB('assets/models/protoss/hightemplar.glb', 'protoss_hightemplar'));
+    tasks.push(() => assetManager.loadGLB('assets/models/zerg/zergling.glb', 'zerg_zergling'));
+    tasks.push(() => assetManager.loadGLB('assets/models/zerg/hydralisk.glb', 'zerg_hydralisk'));
+    tasks.push(() => assetManager.loadGLB('assets/models/zerg/hatchery.glb', 'zerg_hatchery'));
     tasks.push(() => assetManager.loadSound('assets/audio/select.mp3', 'select'));
     tasks.push(() => assetManager.loadSound('assets/audio/move.mp3', 'move'));
 
@@ -39,6 +42,8 @@ export async function preloadAssets(audioManager) {
         'assets/data/protoss/dragoon.json',
         'assets/data/protoss/darktemplar.json',
         'assets/data/protoss/hightemplar.json',
+        'assets/data/zerg/zergling.json',
+        'assets/data/zerg/hydralisk.json',
     ];
     unitDataPaths.forEach(path => {
         const name = `unit_${path.split('/').pop().replace('.json', '')}`;
@@ -113,6 +118,11 @@ export async function preloadAssets(audioManager) {
         'assets/images/protoss/train_dragoon_icon.png',
         'assets/images/protoss/train_darktemplar_icon.png',
         'assets/images/protoss/train_hightemplar_icon.png',
+        'assets/images/zerg/train_zergling_icon.png',
+        'assets/images/zerg/train_hydralisk_icon.png',
+        'assets/images/zerg/build_hatchery_icon.png',
+        'assets/images/zerg/metabolic_boost_icon.png',
+        'assets/images/zerg/muscular_augments_icon.png',
     ];
 
     iconPaths.forEach(path => {
@@ -137,6 +147,10 @@ export async function preloadAssets(audioManager) {
         'assets/images/protoss/dragoon_portrait.png',
         'assets/images/protoss/darktemplar_portrait.png',
         'assets/images/protoss/hightemplar_portrait.png',
+        'assets/images/zerg/zergling_portrait.png',
+        'assets/images/zerg/hydralisk_portrait.png',
+        'assets/images/zerg/hatchery_portrait.png',
+        'assets/images/zerg/larva_portrait.png',
     ];
     portraitPaths.forEach(path => {
         const name = path.split('/').pop().replace('.png', '');

--- a/src/game/selection.js
+++ b/src/game/selection.js
@@ -36,6 +36,10 @@ import { Stalker } from '../protoss/stalker.js';
 import { Dragoon } from '../protoss/dragoon.js';
 import { DarkTemplar } from '../protoss/darktemplar.js';
 import { HighTemplar } from '../protoss/hightemplar.js';
+import { Zergling } from '../zerg/zergling.js';
+import { Hydralisk } from '../zerg/hydralisk.js';
+import { Larva } from '../zerg/larva.js';
+import { Hatchery } from '../zerg/hatchery.js';
 import { audioManager } from '../utils/audio.js';
 
 const raycaster = new THREE.Raycaster();
@@ -145,6 +149,9 @@ export function handleBoxSelection(selectionBox) {
                 selectable instanceof Stalker ||
                 selectable instanceof DarkTemplar ||
                 selectable instanceof HighTemplar ||
+                selectable instanceof Zergling ||
+                selectable instanceof Hydralisk ||
+                selectable instanceof Larva ||
                 selectable instanceof Dragoon ||
                 selectable instanceof CommandCenter ||
                 selectable instanceof SupplyDepot ||
@@ -160,6 +167,7 @@ export function handleBoxSelection(selectionBox) {
                 selectable instanceof ScienceFacility ||
                 selectable instanceof ControlTower ||
                 selectable instanceof PhysicsLab ||
+                selectable instanceof Hatchery ||
                 selectable instanceof ComsatStation ||
                 selectable instanceof NuclearSilo
             ) {

--- a/src/game/spawn.js
+++ b/src/game/spawn.js
@@ -26,7 +26,7 @@ import { ScienceVessel } from '../units/science-vessel.js';
 import { Armory } from '../buildings/armory.js';
 import { ScienceFacility } from '../buildings/science-facility.js';
 import { ControlTower } from '../buildings/control-tower.js';
-import { getTerrainHeight } from '../utils/terrain.js';
+import { getTerrainHeight, spreadCreep } from '../utils/terrain.js';
 import { Valkyrie } from '../units/valkyrie.js';
 import { Battlecruiser } from '../units/battlecruiser.js';
 import { PhysicsLab } from '../buildings/physics-lab.js';
@@ -37,6 +37,10 @@ import { Stalker } from '../protoss/stalker.js';
 import { Dragoon } from '../protoss/dragoon.js';
 import { DarkTemplar } from '../protoss/darktemplar.js';
 import { HighTemplar } from '../protoss/hightemplar.js';
+import { Zergling } from '../zerg/zergling.js';
+import { Hydralisk } from '../zerg/hydralisk.js';
+import { Hatchery } from '../zerg/hatchery.js';
+import { Larva } from '../zerg/larva.js';
 
 let deps;
 
@@ -72,6 +76,18 @@ export function initSpawner(_deps) {
     deps = _deps;
 }
 
+export function spawnLarva(hatchery) {
+    const { scene } = deps;
+    for (let i = 0; i < 3; i++) {
+        const angle = Math.random() * Math.PI * 2;
+        const dist = 2 + Math.random();
+        const pos = hatchery.mesh.position.clone();
+        pos.x += Math.cos(angle) * dist;
+        pos.z += Math.sin(angle) * dist;
+        spawnUnit('Larva', pos);
+    }
+}
+
 export function spawnBuilding(type, position, buildTime, extraData = {}) {
     const { scene, buildings, selectables, collidableObjects, pathfinder } = deps;
     let building;
@@ -105,6 +121,10 @@ export function spawnBuilding(type, position, buildTime, extraData = {}) {
         building = new Armory(position, options);
     } else if (type === 'build_science_facility') {
         building = new ScienceFacility(position, options);
+    } else if (type === 'build_hatchery') {
+        building = new Hatchery(position, options);
+        spreadCreep(position, 8, scene);
+        spawnLarva(building);
     } else if (type === 'Comsat Station') {
         building = new ComsatStation(position, { ...options, parent: extraData.parent });
     } else if (type === 'Nuclear Silo') {
@@ -185,6 +205,17 @@ export function spawnUnit(unitType, position) {
         case 'Dragoon':
             unit = new Dragoon(spawnPos);
             gameState.supplyUsed += 2;
+            break;
+        case 'Zergling':
+            unit = new Zergling(spawnPos);
+            gameState.supplyUsed += 1;
+            break;
+        case 'Hydralisk':
+            unit = new Hydralisk(spawnPos);
+            gameState.supplyUsed += 2;
+            break;
+        case 'Larva':
+            unit = new Larva(spawnPos);
             break;
         case 'Wraith':
             unit = new Wraith(spawnPos);

--- a/src/utils/terrain.js
+++ b/src/utils/terrain.js
@@ -1,9 +1,29 @@
 import * as THREE from 'three';
 
+const creepPatches = [];
+
+export function spreadCreep(position, radius, scene) {
+    const patch = { position: position.clone(), radius };
+    creepPatches.push(patch);
+    if (scene) {
+        const geo = new THREE.CircleGeometry(radius, 32);
+        const mat = new THREE.MeshStandardMaterial({ color: 0x552266 });
+        const mesh = new THREE.Mesh(geo, mat);
+        mesh.rotation.x = -Math.PI / 2;
+        mesh.position.set(position.x, 0.02, position.z);
+        mesh.name = 'creep';
+        scene.add(mesh);
+    }
+}
+
+export function isOnCreep(x, z) {
+    return creepPatches.some(p => Math.hypot(x - p.position.x, z - p.position.z) <= p.radius);
+}
+
 export function getGroundMeshes(scene) {
     const grounds = [];
     scene.traverse(obj => {
-        if (obj.name === 'ground') grounds.push(obj);
+        if (obj.name === 'ground' || obj.name === 'creep') grounds.push(obj);
     });
     return grounds;
 }

--- a/src/zerg/hatchery.js
+++ b/src/zerg/hatchery.js
@@ -1,0 +1,131 @@
+import * as THREE from 'three';
+import { assetManager } from '../utils/asset-manager.js';
+import { spreadCreep } from '../utils/terrain.js';
+
+/** Simple Hatchery building that spreads creep and trains Zerg units */
+export class Hatchery {
+    constructor(position, { isUnderConstruction = false, buildTime = 60, onStateChange = () => {} } = {}) {
+        this.name = 'Hatchery';
+        this.portraitUrl = 'assets/images/zerg/hatchery_portrait.png';
+        this.maxHealth = 1250;
+        this.currentHealth = isUnderConstruction ? 1 : this.maxHealth;
+        this.selected = false;
+        this.isUnderConstruction = isUnderConstruction;
+        this.buildTime = buildTime;
+        this.onStateChange = onStateChange;
+
+        this._commands = [];
+        this.buildQueue = [];
+        this.rallyPoint = new THREE.Vector3(position.x + 4, 0, position.z);
+
+        this.mesh = this.createMesh();
+        this.mesh.position.copy(position);
+        this.mesh.traverse(child => {
+            if (child.isMesh) {
+                child.castShadow = true;
+                child.receiveShadow = true;
+                child.userData.owner = this;
+            }
+        });
+
+        const selGeom = new THREE.RingGeometry(5, 5.5, 64);
+        const selMat = new THREE.MeshBasicMaterial({ color: 0x00ff00, side: THREE.DoubleSide });
+        this.selectionIndicator = new THREE.Mesh(selGeom, selMat);
+        this.selectionIndicator.rotation.x = -Math.PI / 2;
+        this.selectionIndicator.position.y = 0.01;
+        this.selectionIndicator.visible = false;
+        this.mesh.add(this.selectionIndicator);
+
+        spreadCreep(position, 8);
+    }
+
+    createMesh() {
+        try {
+            const asset = assetManager.get('zerg_hatchery');
+            const model = asset.scene.clone();
+            model.scale.set(0.5, 0.5, 0.5);
+            return model;
+        } catch (e) {
+            const geo = new THREE.CylinderGeometry(4, 6, 3, 12);
+            const mat = new THREE.MeshStandardMaterial({ color: 0x552266 });
+            const mesh = new THREE.Mesh(geo, mat);
+            mesh.position.y = 1.5;
+            return mesh;
+        }
+    }
+
+    get commands() { return this._commands; }
+
+    updateCommands(gameState) {
+        const cmds = new Array(12).fill(null);
+        cmds[0] = { command: 'train_zergling', hotkey: 'Z', icon: 'assets/images/zerg/train_zergling_icon.png', name: 'Train Zergling', cost: { minerals: 50 }, buildTime: 17 };
+        cmds[1] = { command: 'train_hydralisk', hotkey: 'H', icon: 'assets/images/zerg/train_hydralisk_icon.png', name: 'Train Hydralisk', cost: { minerals: 100, vespene: 50 }, buildTime: 25 };
+        if (!gameState.upgrades.metabolicBoost) {
+            cmds[8] = { command: 'evolve_metabolic_boost', hotkey: 'M', icon: 'assets/images/zerg/metabolic_boost_icon.png', name: 'Evolve Metabolic Boost', cost: { minerals: 100, vespene: 100 }, researchTime: 60 };
+        }
+        if (!gameState.upgrades.muscularAugments) {
+            cmds[9] = { command: 'evolve_muscular_augments', hotkey: 'U', icon: 'assets/images/zerg/muscular_augments_icon.png', name: 'Evolve Muscular Augments', cost: { minerals: 150, vespene: 150 }, researchTime: 90 };
+        }
+        this._commands = cmds;
+    }
+
+    onConstructionComplete(gameState) {
+        this.isUnderConstruction = false;
+        this.currentHealth = this.maxHealth;
+        this.mesh.traverse(child => {
+            if (child.material && child.material.transparent) {
+                child.material.opacity = 1.0;
+                child.material.transparent = false;
+            }
+        });
+        this.updateCommands(gameState);
+    }
+
+    select() { this.selected = true; this.selectionIndicator.visible = true; }
+    deselect() { this.selected = false; this.selectionIndicator.visible = false; }
+
+    executeCommand(commandName, gameState, statusCallback) {
+        const command = this._commands.find(c => c && c.command === commandName);
+        if (!command) return;
+        if (commandName.startsWith('train_')) {
+            if (gameState.minerals < command.cost.minerals || (command.cost.vespene && gameState.vespene < command.cost.vespene)) {
+                statusCallback('Not enough resources.');
+                return;
+            }
+            gameState.minerals -= command.cost.minerals;
+            if (command.cost.vespene) gameState.vespene -= command.cost.vespene;
+            const unitType = commandName === 'train_zergling' ? 'Zergling' : 'Hydralisk';
+            this.buildQueue.push({ type: unitType, progress: 0, buildTime: command.buildTime });
+            statusCallback(`${unitType} spawning...`);
+        } else if (commandName === 'evolve_metabolic_boost') {
+            if (gameState.minerals < command.cost.minerals || gameState.vespene < command.cost.vespene) { statusCallback('Not enough resources.'); return; }
+            gameState.minerals -= command.cost.minerals;
+            gameState.vespene -= command.cost.vespene;
+            this.buildQueue.push({ type: 'metabolicBoost', progress: 0, buildTime: command.researchTime });
+            statusCallback('Researching Metabolic Boost...');
+        } else if (commandName === 'evolve_muscular_augments') {
+            if (gameState.minerals < command.cost.minerals || gameState.vespene < command.cost.vespene) { statusCallback('Not enough resources.'); return; }
+            gameState.minerals -= command.cost.minerals;
+            gameState.vespene -= command.cost.vespene;
+            this.buildQueue.push({ type: 'muscularAugments', progress: 0, buildTime: command.researchTime });
+            statusCallback('Researching Muscular Augments...');
+        }
+    }
+
+    update(delta, gameState, spawnUnitCallback) {
+        if (this.buildQueue.length === 0) return;
+        const item = this.buildQueue[0];
+        item.progress += delta;
+        if (item.progress >= item.buildTime) {
+            this.buildQueue.shift();
+            if (item.type === 'metabolicBoost') {
+                gameState.upgrades.metabolicBoost = true;
+            } else if (item.type === 'muscularAugments') {
+                gameState.upgrades.muscularAugments = true;
+            } else {
+                spawnUnitCallback(item.type, this.rallyPoint.clone());
+            }
+            this.updateCommands(gameState);
+        }
+    }
+}

--- a/src/zerg/hydralisk.js
+++ b/src/zerg/hydralisk.js
@@ -1,0 +1,57 @@
+import * as THREE from 'three';
+import { Infantry } from '../units/infantry.js';
+import { assetManager } from '../utils/asset-manager.js';
+
+export class Hydralisk extends Infantry {
+    constructor(position) {
+        super(position);
+        this.name = 'Hydralisk';
+        this.portraitUrl = 'assets/images/zerg/hydralisk_portrait.png';
+        this.maxHealth = 80;
+        this.currentHealth = 80;
+        this.speed = 3.5;
+        this.commands = [
+            { command: 'move', hotkey: 'M', icon: 'assets/images/move_icon.png', name: 'Move' },
+            { command: 'stop', hotkey: 'S', icon: 'assets/images/stop_icon.png', name: 'Stop' },
+            { command: 'attack', hotkey: 'A', icon: 'assets/images/attack_icon.png', name: 'Attack' },
+        ];
+        try {
+            const asset = assetManager.get('zerg_hydralisk');
+            this.mesh = this.createMeshFromGLB(asset);
+        } catch (e) {
+            console.warn('Could not load hydralisk model, using procedural fallback.', e);
+            this.mesh = this.createProceduralMesh();
+        }
+        this.setup(position);
+    }
+
+    createMeshFromGLB(asset) {
+        const model = asset.scene.clone();
+        const box = new THREE.Box3().setFromObject(model);
+        const size = box.getSize(new THREE.Vector3());
+        const desiredSize = 2.5;
+        const maxDim = Math.max(size.x, size.y, size.z);
+        if (maxDim > 0) {
+            const scale = desiredSize / maxDim;
+            model.scale.set(scale, scale, scale);
+        }
+        model.traverse(child => {
+            if (child.isMesh) {
+                child.castShadow = true;
+                child.userData.owner = this;
+            }
+        });
+        return model;
+    }
+
+    createProceduralMesh() {
+        const body = new THREE.Mesh(
+            new THREE.ConeGeometry(0.5, 1.5, 6),
+            new THREE.MeshStandardMaterial({ color: 0x663388 })
+        );
+        body.position.y = 0.75;
+        body.castShadow = true;
+        body.userData.owner = this;
+        return body;
+    }
+}

--- a/src/zerg/larva.js
+++ b/src/zerg/larva.js
@@ -1,0 +1,27 @@
+import * as THREE from 'three';
+import { Infantry } from '../units/infantry.js';
+
+export class Larva extends Infantry {
+    constructor(position) {
+        super(position);
+        this.name = 'Larva';
+        this.portraitUrl = 'assets/images/zerg/larva_portrait.png';
+        this.maxHealth = 25;
+        this.currentHealth = 25;
+        this.speed = 2;
+        this.commands = [];
+        this.mesh = this.createProceduralMesh();
+        this.setup(position);
+    }
+
+    createProceduralMesh() {
+        const body = new THREE.Mesh(
+            new THREE.SphereGeometry(0.3, 8, 8),
+            new THREE.MeshStandardMaterial({ color: 0xaa55ff })
+        );
+        body.position.y = 0.3;
+        body.castShadow = true;
+        body.userData.owner = this;
+        return body;
+    }
+}

--- a/src/zerg/zergling.js
+++ b/src/zerg/zergling.js
@@ -1,0 +1,57 @@
+import * as THREE from 'three';
+import { Infantry } from '../units/infantry.js';
+import { assetManager } from '../utils/asset-manager.js';
+
+export class Zergling extends Infantry {
+    constructor(position) {
+        super(position);
+        this.name = 'Zergling';
+        this.portraitUrl = 'assets/images/zerg/zergling_portrait.png';
+        this.maxHealth = 35;
+        this.currentHealth = 35;
+        this.speed = 4.5;
+        this.commands = [
+            { command: 'move', hotkey: 'M', icon: 'assets/images/move_icon.png', name: 'Move' },
+            { command: 'stop', hotkey: 'S', icon: 'assets/images/stop_icon.png', name: 'Stop' },
+            { command: 'attack', hotkey: 'A', icon: 'assets/images/attack_icon.png', name: 'Attack' },
+        ];
+        try {
+            const asset = assetManager.get('zerg_zergling');
+            this.mesh = this.createMeshFromGLB(asset);
+        } catch (e) {
+            console.warn('Could not load zergling model, using procedural fallback.', e);
+            this.mesh = this.createProceduralMesh();
+        }
+        this.setup(position);
+    }
+
+    createMeshFromGLB(asset) {
+        const model = asset.scene.clone();
+        const box = new THREE.Box3().setFromObject(model);
+        const size = box.getSize(new THREE.Vector3());
+        const desiredSize = 1.5;
+        const maxDim = Math.max(size.x, size.y, size.z);
+        if (maxDim > 0) {
+            const scale = desiredSize / maxDim;
+            model.scale.set(scale, scale, scale);
+        }
+        model.traverse(child => {
+            if (child.isMesh) {
+                child.castShadow = true;
+                child.userData.owner = this;
+            }
+        });
+        return model;
+    }
+
+    createProceduralMesh() {
+        const body = new THREE.Mesh(
+            new THREE.SphereGeometry(0.4, 8, 8),
+            new THREE.MeshStandardMaterial({ color: 0x8844aa })
+        );
+        body.position.y = 0.4;
+        body.castShadow = true;
+        body.userData.owner = this;
+        return body;
+    }
+}


### PR DESCRIPTION
## Summary
- archive existing changelog entries
- implement creep tracking and spread helpers in terrain utils
- add Zergling, Hydralisk, Larva units and Hatchery building
- support Zerg buildings/units in spawn, selection, preloader, and initial state
- include simple Zerg upgrades in game state
- document required new art assets in `needed.json`

## Testing
- `npm install` *(fails: no package.json scripts)*

------
https://chatgpt.com/codex/tasks/task_e_687037b34ebc83328e07d58f1de54086